### PR TITLE
Configure binary and brew releases

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
+* @joshma @colinking

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -2,14 +2,16 @@
 
 ## Releases
 
-Releases are managed by [GoReleaser](https://github.com/goreleaser/goreleaser). This builds binaries for various architectures and uploads them as GitHub artifacts. It also releases to Homebrew via [`airplanedev/homebrew-tap`](https://github.com/airplanedev/homebrew-tap). This happens automatically via GitHub Actions when you push a new git tag:
+Releases are managed by [GoReleaser](https://github.com/goreleaser/goreleaser). This produces binaries for various architectures and uploads them as GitHub artifacts. It also releases to Homebrew through [`airplanedev/homebrew-tap`](https://github.com/airplanedev/homebrew-tap).
+
+This all happens automatically via GitHub Actions whenever a new tag is published:
 
 ```sh
 git tag v0.0.1
 git push origin v0.0.1
 ```
 
-You can test this locally by running:
+You can test this build process locally by running:
 
 ```sh
 # or https://goreleaser.com/install/

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,19 @@
+# Contributing to the Airplane CLI
+
+## Releases
+
+Releases are managed by [GoReleaser](https://github.com/goreleaser/goreleaser). This builds binaries for various architectures and uploads them as GitHub artifacts. It also releases to Homebrew via [`airplanedev/homebrew-tap`](https://github.com/airplanedev/homebrew-tap). This happens automatically via GitHub Actions when you push a new git tag:
+
+```sh
+git tag v0.0.1
+git push origin v0.0.1
+```
+
+You can test this locally by running:
+
+```sh
+# or https://goreleaser.com/install/
+brew install goreleaser/tap/goreleaser
+
+goreleaser --snapshot --skip-publish --rm-dist
+```

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -7,8 +7,9 @@ Releases are managed by [GoReleaser](https://github.com/goreleaser/goreleaser). 
 This all happens automatically via GitHub Actions whenever a new tag is published:
 
 ```sh
-git tag v0.0.1
-git push origin v0.0.1
+export AIRPLANE_CLI_TAG=v0.0.1-alpha.2 && \
+  git tag ${AIRPLANE_CLI_TAG} && \
+  git push origin ${AIRPLANE_CLI_TAG}
 ```
 
 You can test this build process locally by running:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,31 @@
+name: release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.16
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          version: latest
+          args: release --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GORELEASER_GITHUB_TOKEN }}
+      - name: Upload checksums as artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: checksums
+          path: dist/checksums.txt

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+dist/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -14,7 +14,18 @@ builds:
       - darwin
     mod_timestamp: "{{ .CommitTimestamp }}"
 archives:
-  - replacements:
+  - files: [only-the-binary*]
+    wrap_in_directory: false
+    replacements:
+      darwin: Darwin
+      linux: Linux
+      windows: Windows
+      386: i386
+      amd64: x86_64
+  - id: binary
+    format: binary
+    files: [only-the-binary*]
+    replacements:
       darwin: Darwin
       linux: Linux
       windows: Windows

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,5 +1,6 @@
 # Docs: https://goreleaser.com/
 
+project_name: airplane
 before:
   hooks:
     - go mod tidy

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,36 @@
+# Docs: https://goreleaser.com/
+
+before:
+  hooks:
+    - go mod tidy
+builds:
+  - main: ./cmd/airplane/main.go
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - windows
+      - darwin
+    mod_timestamp: "{{ .CommitTimestamp }}"
+archives:
+  - replacements:
+      darwin: Darwin
+      linux: Linux
+      windows: Windows
+      386: i386
+      amd64: x86_64
+checksum:
+  name_template: "checksums.txt"
+snapshot:
+  name_template: "{{ .Tag }}-next"
+changelog:
+  sort: asc
+brews:
+  - tap:
+      owner: airplanedev
+      name: homebrew-tap
+    homepage: "https://airplane.dev"
+    test: |
+      system "#{bin}/airplane help"
+release:
+  prerelease: auto

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -44,5 +44,8 @@ brews:
     homepage: "https://airplane.dev"
     test: |
       system "#{bin}/airplane help"
+    commit_author:
+      name: AirplaneBot
+      email: bot-github@airplane.dev
 release:
   prerelease: auto

--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+# Airplane CLI

--- a/Readme.md
+++ b/Readme.md
@@ -1,2 +1,0 @@
-
-  Airplane CLI


### PR DESCRIPTION
This PR configures GoReleaser to build and release binaries as GitHub releases, whenever we publish a new versioned tag. It also publishes releases over on https://github.com/airplanedev/homebrew-tap which allows you to `brew install airplanedev/tap/airplane`.

We'll want to add install scripts for installing these binaries for non-homebrew users: https://github.com/denoland/deno_install

To publish from GHA, I've added an @AirplaneBot user with write access to just this repo + homebrew-tap. I've added a PAT for this account as a secret in this repo. For context, see: https://stackoverflow.com/a/62143130/1935727