### PR TITLE
Fix conf-based login error

### DIFF
--- a/pkg/cmd/login/login.go
+++ b/pkg/cmd/login/login.go
@@ -28,29 +28,27 @@ func New(c *cli.Config) *cobra.Command {
 // Run runs the login command.
 func run(ctx context.Context, cmd *cobra.Command, c *cli.Config) error {
 	cfg, err := conf.ReadDefault()
-
-	if err != nil {
-		if errors.Is(err, conf.ErrMissing) {
-			srv, err := token.NewServer(ctx)
-			if err != nil {
-				return err
-			}
-			defer srv.Close()
-
-			open(cmd, c.Client.LoginURL(srv.URL()))
-
-			select {
-			case <-ctx.Done():
-				return ctx.Err()
-
-			case token := <-srv.Token():
-				cfg.Token = token
-			}
-
-			if err := conf.WriteDefault(cfg); err != nil {
-				return err
-			}
+	if errors.Is(err, conf.ErrMissing) {
+		srv, err := token.NewServer(ctx)
+		if err != nil {
+			return err
 		}
+		defer srv.Close()
+
+		open(cmd, c.Client.LoginURL(srv.URL()))
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+
+		case token := <-srv.Token():
+			cfg.Token = token
+		}
+
+		if err := conf.WriteDefault(cfg); err != nil {
+			return err
+		}
+	} else if err != nil {
 		return err
 	}
 

--- a/pkg/token/server.go
+++ b/pkg/token/server.go
@@ -104,8 +104,8 @@ func (srv *Server) Close() error {
 	// StateNew connections from Chrome. These get ignored after 5s during shutdown,
 	// but that would cause `airplane login` to hang for 5s.
 	//
-	// To handle this, we apply a short timeout to our server shutdown to force
-	// it to close those StateNew connections within a short period of time.
+	// To handle this, we apply a short timeout to force it to close
+	// those StateNew connections within a short period of time.
 	//
 	// See: https://github.com/golang/go/issues/22682#issuecomment-343987847
 	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)

--- a/pkg/token/server.go
+++ b/pkg/token/server.go
@@ -2,7 +2,6 @@ package token
 
 import (
 	"context"
-	"fmt"
 	"net"
 	"net/http"
 	"sync"
@@ -77,13 +76,10 @@ func (srv *Server) Token() <-chan string {
 
 // ServeHTTP implementation.
 func (srv *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	fmt.Printf("received connection...\n")
 	select {
 	case <-r.Context().Done():
-		fmt.Printf("closing from context...\n")
 	case srv.tokens <- r.URL.Query().Get("token"):
 		http.Redirect(w, r, DocsURL, http.StatusSeeOther)
-		fmt.Printf("closing from token...\n")
 	}
 }
 


### PR DESCRIPTION
This fixes an issue with `airplane login` that would lead to a "conf missing" error.

While here, I also noticed that `airplane login` was slow to shutdown when logging in through Chrome. Fixed by adding a `ReadHeaderTimeout`.