### PR TITLE
Recommend `brew update` in installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ brew install airplanedev/tap/airplane
 To upgrade to the latest version with Homebrew:
 
 ```sh
-brew upgrade airplane
+brew update && brew upgrade airplane
 ```
 
 Otherwise, you can install with `curl`:


### PR DESCRIPTION
To upgrade the airplane CLI, you'll have to run `brew update` or else the latest version will not be installed.