### PR TITLE
Add version command

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -8,6 +8,8 @@ builds:
   - main: ./cmd/airplane/main.go
     env:
       - CGO_ENABLED=0
+    ldflags:
+      - -s -w -X github.com/airplanedev/cli/pkg/cmd/version.version={{.Version}} -X github.com/airplanedev/cli/pkg/cmd/version.commitDate={{.Date}}
     goos:
       - linux
       - windows

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -9,7 +9,7 @@ builds:
     env:
       - CGO_ENABLED=0
     ldflags:
-      - -s -w -X github.com/airplanedev/cli/pkg/cmd/version.version={{.Version}} -X github.com/airplanedev/cli/pkg/cmd/version.commitDate={{.Date}}
+      - -s -w -X github.com/airplanedev/cli/pkg/cmd/version.version={{.Version}} -X github.com/airplanedev/cli/pkg/cmd/version.compileDate={{.Date}}
     goos:
       - linux
       - windows

--- a/pkg/cli/config.go
+++ b/pkg/cli/config.go
@@ -12,6 +12,9 @@ type Config struct {
 	// It is initialized in the root command and passed
 	// down to all commands.
 	Client *api.Client
+
+	// Version indicates if the CLI version should be printed.
+	Version bool
 }
 
 // Must should be used for Cobra initialize commands that can return an error

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -10,6 +10,7 @@ import (
 	"github.com/airplanedev/cli/pkg/cmd/auth"
 	"github.com/airplanedev/cli/pkg/cmd/runs"
 	"github.com/airplanedev/cli/pkg/cmd/tasks"
+	"github.com/airplanedev/cli/pkg/cmd/version"
 	"github.com/airplanedev/cli/pkg/conf"
 	"github.com/airplanedev/cli/pkg/print"
 	isatty "github.com/mattn/go-isatty"
@@ -62,6 +63,7 @@ func New() *cobra.Command {
 	// Set usage, help functions.
 	cmd.SetUsageFunc(usage)
 	cmd.SetHelpFunc(help)
+	cmd.SetVersionTemplate(version.Version())
 
 	// Persistent flags, set globally to all commands.
 	cmd.PersistentFlags().StringVarP(&cfg.Client.Host, "host", "", api.Host, "Airplane API Host.")
@@ -70,11 +72,13 @@ func New() *cobra.Command {
 		defaultFormat = "json"
 	}
 	cmd.PersistentFlags().StringVarP(&output, "output", "o", defaultFormat, "The format to use for output (json|yaml|table).")
+	cmd.PersistentFlags().BoolVarP(&cfg.Version, "version", "v", false, "Show the CLI version.")
 
 	// Sub-commands.
 	cmd.AddCommand(auth.New(cfg))
 	cmd.AddCommand(tasks.New(cfg))
 	cmd.AddCommand(runs.New(cfg))
+	cmd.AddCommand(version.New(cfg))
 
 	return cmd
 }

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -72,7 +72,7 @@ func New() *cobra.Command {
 		defaultFormat = "json"
 	}
 	cmd.PersistentFlags().StringVarP(&output, "output", "o", defaultFormat, "The format to use for output (json|yaml|table).")
-	cmd.PersistentFlags().BoolVarP(&cfg.Version, "version", "v", false, "Show the CLI version.")
+	cmd.PersistentFlags().BoolVarP(&cfg.Version, "version", "v", false, "Print the CLI version.")
 
 	// Sub-commands.
 	cmd.AddCommand(auth.New(cfg))

--- a/pkg/cmd/version/version.go
+++ b/pkg/cmd/version/version.go
@@ -18,8 +18,8 @@ var (
 func New(c *cli.Config) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "version",
-		Short: "Prints the CLI version",
-		Long:  "Prints the CLI version",
+		Short: "Print the CLI version",
+		Long:  "Print the CLI version",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return run(cmd.Context())
 		},

--- a/pkg/cmd/version/version.go
+++ b/pkg/cmd/version/version.go
@@ -1,0 +1,39 @@
+package version
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/airplanedev/cli/pkg/cli"
+	"github.com/spf13/cobra"
+)
+
+// Set by Go Releaser.
+var (
+	version     string = "<unknown>"
+	compileDate string = "<unknown>"
+)
+
+func New(c *cli.Config) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "version",
+		Short: "Prints the CLI version",
+		Long:  "Prints the CLI version",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return run(cmd.Context())
+		},
+	}
+
+	return cmd
+}
+
+func Version() string {
+	return fmt.Sprintf("Version: %s (%s)\n", version, compileDate)
+}
+
+func run(ctx context.Context) error {
+	fmt.Fprint(os.Stderr, Version())
+
+	return nil
+}


### PR DESCRIPTION
Cobra automatically reports the CLI version with the `-v` and `--version` flag, but it doesn't report it through a `version` command. This PR adds that and adds the publish date, too.

## Before

```
❯ airplane help

Usage:
  airplane <command> [flags]

Commands:
  auth       Manage CLI authentication
  help       Help about any command
  runs       Manage runs
  tasks      Manage tasks

Flags:
  -h, --help            help for airplane
      --host string     Airplane API Host. (default "api.airplane.dev")
  -o, --output string   The format to use for output (json|yaml|table). (default "table")

...


❯ airplane -v
airplane version 0.0.5

❯ airplane --version
airplane version 0.0.5

❯ airplane version

  Error: unknown command "version" for "airplane"
```

## After

```
❯ ./dist/airplane_darwin_arm64/airplane help

Usage:
  airplane <command> [flags]

Commands:
  auth       Manage CLI authentication
  help       Help about any command
  runs       Manage runs
  tasks      Manage tasks
  version    Print the CLI version

Flags:
  -h, --help            help for airplane
      --host string     Airplane API Host. (default "api.airplane.dev")
  -o, --output string   The format to use for output (json|yaml|table). (default "table")
  -v, --version         Print the CLI version.

...

❯ ./dist/airplane_darwin_arm64/airplane --version
Version: v0.0.5-next (2021-03-30T00:10:06Z)

❯ ./dist/airplane_darwin_arm64/airplane -v
Version: v0.0.5-next (2021-03-30T00:10:06Z)

❯ ./dist/airplane_darwin_arm64/airplane version
Version: v0.0.5-next (2021-03-30T00:10:06Z)
```
