### PR TITLE
Unpin major versions of node in builder

### DIFF
--- a/pkg/build/node.go
+++ b/pkg/build/node.go
@@ -23,7 +23,7 @@ func node(root string, args Args) (string, error) {
 
 	// Default version.
 	if version == "" {
-		version = "15.8"
+		version = "15"
 	}
 
 	// Make sure that entrypoint and `package.json` exist.
@@ -75,7 +75,7 @@ ENTRYPOINT ["node", "{{ .Main }}"]
 		Commands    []string
 		Main        string
 	}
-	data.NodeVersion = version
+	data.NodeVersion = expandVersion(version)
 	data.Commands = cmds
 	data.Main = entrypoint
 
@@ -85,4 +85,19 @@ ENTRYPOINT ["node", "{{ .Main }}"]
 	}
 
 	return buf.String(), nil
+}
+
+// expandVersion returns a pinned minor version of Node to use
+func expandVersion(version string) string {
+	switch version {
+	case "15":
+		return "15.12"
+	case "14":
+		return "14.16"
+	case "12":
+		return "12.22"
+	default:
+		// Assume the version is already a more-specific version - default to just returning it back
+		return version
+	}
 }

--- a/pkg/build/node.go
+++ b/pkg/build/node.go
@@ -21,11 +21,6 @@ func node(root string, args Args) (string, error) {
 	var lang = args["language"]
 	var cmds []string
 
-	// Default version.
-	if version == "" {
-		version = "15"
-	}
-
 	// Make sure that entrypoint and `package.json` exist.
 	if err := exist(main, deps); err != nil {
 		return "", err
@@ -87,9 +82,12 @@ ENTRYPOINT ["node", "{{ .Main }}"]
 	return buf.String(), nil
 }
 
-// expandVersion returns a pinned minor version of Node to use
-func expandVersion(version string) string {
+// expandNodeVersion returns a pinned minor version of Node to use
+func expandNodeVersion(version string) string {
 	switch version {
+	case "":
+		// If empty, use default of 15
+		fallthrough
 	case "15":
 		return "15.12"
 	case "14":

--- a/pkg/build/node.go
+++ b/pkg/build/node.go
@@ -70,7 +70,7 @@ ENTRYPOINT ["node", "{{ .Main }}"]
 		Commands    []string
 		Main        string
 	}
-	data.NodeVersion = expandVersion(version)
+	data.NodeVersion = expandNodeVersion(version)
 	data.Commands = cmds
 	data.Main = entrypoint
 

--- a/pkg/build/node_test.go
+++ b/pkg/build/node_test.go
@@ -1,0 +1,18 @@
+package build
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNodeVersion(t *testing.T) {
+	t.Run("expand versions", func(t *testing.T) {
+		var assert = require.New(t)
+		assert.Equal("15.12", expandNodeVersion(""))
+		assert.Equal("15.12", expandNodeVersion("15"))
+		assert.Equal("14.16", expandNodeVersion("14"))
+		assert.Equal("12.22", expandNodeVersion("12"))
+		assert.Equal("16.23-alpha", expandNodeVersion("16.23-alpha"))
+	})
+}


### PR DESCRIPTION
Supports e.g. "15" for version instead of the full version, and resolves
that version to the pinned minor version.
