### PR TITLE
Support per-host tokens

### DIFF
--- a/pkg/api/client.go
+++ b/pkg/api/client.go
@@ -54,7 +54,9 @@ type Client struct {
 
 // AppURL returns the app URL.
 func (c Client) appURL() *url.URL {
-	apphost := strings.ReplaceAll(c.host(), "api", "app")
+	apphost := c.host()
+	apphost = strings.ReplaceAll(apphost, "api.airstage.app", "web.airstage.app")
+	apphost = strings.ReplaceAll(apphost, "api", "app")
 	u, _ := url.Parse("https://" + apphost)
 	return u
 }

--- a/pkg/cmd/auth/login/login.go
+++ b/pkg/cmd/auth/login/login.go
@@ -90,7 +90,7 @@ func login(ctx context.Context, c *cli.Config) error {
 		if err != nil {
 			return err
 		}
-		cfg.Token = token
+		cfg.Tokens[c.Client.Host] = token
 		if err := conf.WriteDefault(cfg); err != nil {
 			return err
 		}

--- a/pkg/cmd/auth/login/login.go
+++ b/pkg/cmd/auth/login/login.go
@@ -87,7 +87,7 @@ func login(ctx context.Context, c *cli.Config) error {
 	case token := <-srv.Token():
 		c.Client.Token = token
 		cfg, err := conf.ReadDefault()
-		if err != nil {
+		if err != nil && !errors.Is(err, conf.ErrMissing) {
 			return err
 		}
 		if cfg.Tokens == nil {

--- a/pkg/cmd/auth/login/login.go
+++ b/pkg/cmd/auth/login/login.go
@@ -90,6 +90,9 @@ func login(ctx context.Context, c *cli.Config) error {
 		if err != nil {
 			return err
 		}
+		if cfg.Tokens == nil {
+			cfg.Tokens = map[string]string{}
+		}
 		cfg.Tokens[c.Client.Host] = token
 		if err := conf.WriteDefault(cfg); err != nil {
 			return err

--- a/pkg/cmd/auth/logout/logout.go
+++ b/pkg/cmd/auth/logout/logout.go
@@ -23,12 +23,14 @@ func New(c *cli.Config) *cobra.Command {
 
 func run(ctx context.Context, c *cli.Config) error {
 	cfg, err := conf.ReadDefault()
-	if !errors.Is(err, conf.ErrMissing) {
-		cfg.Tokens[c.Client.Host] = ""
+	if err == nil || !errors.Is(err, conf.ErrMissing) {
+		delete(cfg.Tokens, c.Client.Host)
 
 		if err := conf.WriteDefault(cfg); err != nil {
 			return err
 		}
+	} else if err != nil {
+		return err
 	}
 
 	logger.Log("Logged out.")

--- a/pkg/cmd/auth/logout/logout.go
+++ b/pkg/cmd/auth/logout/logout.go
@@ -23,14 +23,16 @@ func New(c *cli.Config) *cobra.Command {
 
 func run(ctx context.Context, c *cli.Config) error {
 	cfg, err := conf.ReadDefault()
-	if err == nil || !errors.Is(err, conf.ErrMissing) {
+	if !errors.Is(err, conf.ErrMissing) {
+		if err != nil {
+			return err
+		}
+
 		delete(cfg.Tokens, c.Client.Host)
 
 		if err := conf.WriteDefault(cfg); err != nil {
 			return err
 		}
-	} else if err != nil {
-		return err
 	}
 
 	logger.Log("Logged out.")

--- a/pkg/cmd/auth/logout/logout.go
+++ b/pkg/cmd/auth/logout/logout.go
@@ -24,7 +24,7 @@ func New(c *cli.Config) *cobra.Command {
 func run(ctx context.Context, c *cli.Config) error {
 	cfg, err := conf.ReadDefault()
 	if !errors.Is(err, conf.ErrMissing) {
-		cfg.Token = ""
+		cfg.Tokens[c.Client.Host] = ""
 
 		if err := conf.WriteDefault(cfg); err != nil {
 			return err

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -38,7 +38,7 @@ func New() *cobra.Command {
 		`),
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			if c, err := conf.ReadDefault(); err == nil {
-				cfg.Client.Token = c.Token
+				cfg.Client.Token = c.Token(cfg.Client.Host)
 			}
 
 			switch output {

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -38,7 +38,7 @@ func New() *cobra.Command {
 		`),
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			if c, err := conf.ReadDefault(); err == nil {
-				cfg.Client.Token = c.Token(cfg.Client.Host)
+				cfg.Client.Token = c.Tokens[cfg.Client.Host]
 			}
 
 			switch output {

--- a/pkg/conf/conf.go
+++ b/pkg/conf/conf.go
@@ -64,7 +64,7 @@ func Write(path string, cfg Config) error {
 		return errors.Wrap(err, "mkdir")
 	}
 
-	buf, err := json.Marshal(cfg)
+	buf, err := json.MarshalIndent(cfg, "", "	")
 	if err != nil {
 		return errors.Wrap(err, "marshal config")
 	}

--- a/pkg/conf/conf.go
+++ b/pkg/conf/conf.go
@@ -16,7 +16,7 @@ var (
 
 // Config represents the configuration.
 type Config struct {
-	Token string `json:"token,omitempty"`
+	Tokens map[string]string `json:"tokens,omitempty"`
 }
 
 // Path returns the default config path.

--- a/pkg/conf/conf_test.go
+++ b/pkg/conf/conf_test.go
@@ -28,13 +28,13 @@ func TestConfig(t *testing.T) {
 		var path = filepath.Join(homedir, ".airplane", "config")
 
 		err := Write(path, Config{
-			Token: "foo",
+			Tokens: map[string]string{"airplane.dev": "foo"},
 		})
 		assert.NoError(err)
 
 		cfg, err := Read(path)
 		assert.NoError(err)
-		assert.Equal("foo", cfg.Token)
+		assert.Equal("foo", cfg.Tokens["airplane.dev"])
 	})
 
 	t.Run("overwrite", func(t *testing.T) {
@@ -44,24 +44,24 @@ func TestConfig(t *testing.T) {
 
 		{
 			err := Write(path, Config{
-				Token: "foo",
+				Tokens: map[string]string{"airplane.dev": "foo"},
 			})
 			assert.NoError(err)
 
 			cfg, err := Read(path)
 			assert.NoError(err)
-			assert.Equal("foo", cfg.Token)
+			assert.Equal("foo", cfg.Tokens["airplane.dev"])
 		}
 
 		{
 			err := Write(path, Config{
-				Token: "baz",
+				Tokens: map[string]string{"airplane.dev": "baz"},
 			})
 			assert.NoError(err)
 
 			cfg, err := Read(path)
 			assert.NoError(err)
-			assert.Equal("baz", cfg.Token)
+			assert.Equal("baz", cfg.Tokens["airplane.dev"])
 		}
 	})
 }


### PR DESCRIPTION
This is useful for our internal development, where we test the CLI against a local/staging/production host. Previously tokens were global, but now they are per-host so there will be a token persisted for each host you've used.