### PR TITLE
Support root directory override

### DIFF
--- a/pkg/cmd/tasks/deploy/deploy.go
+++ b/pkg/cmd/tasks/deploy/deploy.go
@@ -105,7 +105,7 @@ func run(ctx context.Context, cfg config) error {
 		}
 
 		b, err := build.New(build.Config{
-			Root:    dir.Dir,
+			Root:    dir.DefinitionRootPath(),
 			Builder: def.Builder,
 			Args:    build.Args(def.BuilderConfig),
 			Writer:  output,

--- a/pkg/cmd/tasks/initcmd/sample.go
+++ b/pkg/cmd/tasks/initcmd/sample.go
@@ -60,7 +60,7 @@ func initFromSample(cfg config) error {
 
 	// Copy the sample code from the temporary directory into the user's
 	// local directory.
-	if err := copy.Copy(dir.Dir, outputdir); err != nil {
+	if err := copy.Copy(dir.DefinitionRootPath(), outputdir); err != nil {
 		return errors.Wrap(err, "copying sample directory")
 	}
 

--- a/pkg/taskdir/directory.go
+++ b/pkg/taskdir/directory.go
@@ -43,6 +43,10 @@ func Open(file string) (TaskDirectory, error) {
 	}
 	td.rootPath = path.Join(filepath.Dir(td.defPath), def.Root)
 
+	if !strings.HasPrefix(td.defPath, td.rootPath+string(filepath.Separator)) {
+		return TaskDirectory{}, errors.Errorf("%s must be inside of the task's root directory: %s", path.Base(td.defPath), td.rootPath)
+	}
+
 	return td, nil
 }
 

--- a/pkg/taskdir/directory.go
+++ b/pkg/taskdir/directory.go
@@ -2,6 +2,7 @@ package taskdir
 
 import (
 	"io"
+	"path"
 	"path/filepath"
 	"strings"
 
@@ -9,11 +10,10 @@ import (
 )
 
 type TaskDirectory struct {
-	// Dir is the absolute local path to the directory that TaskDirectory represents.
-	Dir string
-
-	// path is the local path, relative to Dir, of the airplane.yml task definition.
-	path string
+	// rootPath is the absolute path to the task's root directory.
+	rootPath string
+	// path is the absolute path of the airplane.yml task definition.
+	defPath string
 	// closer is used to clean up TaskDirectory.
 	closer io.Closer
 }
@@ -26,20 +26,32 @@ func Open(file string) (TaskDirectory, error) {
 	var td TaskDirectory
 	var err error
 	if strings.HasPrefix(file, "github.com/") || strings.HasPrefix(file, "https://github.com/") {
-		td.path, td.closer, err = openGitHubDirectory(file)
+		td.defPath, td.closer, err = openGitHubDirectory(file)
 		if err != nil {
 			return TaskDirectory{}, err
 		}
 	} else {
-		td.path = file
+		td.defPath, err = filepath.Abs(file)
+		if err != nil {
+			return TaskDirectory{}, errors.Wrap(err, "converting local file path to absolute path")
+		}
 	}
 
-	td.Dir, err = filepath.Abs(filepath.Dir(td.path))
+	def, err := td.ReadDefinition()
 	if err != nil {
-		return TaskDirectory{}, errors.Wrap(err, "parsing file directory")
+		return TaskDirectory{}, err
 	}
+	td.rootPath = path.Join(filepath.Dir(td.defPath), def.Root)
 
 	return td, nil
+}
+
+func (this TaskDirectory) DefinitionPath() string {
+	return this.defPath
+}
+
+func (this TaskDirectory) DefinitionRootPath() string {
+	return this.rootPath
 }
 
 func (this TaskDirectory) Close() error {

--- a/pkg/taskdir/taskdef.go
+++ b/pkg/taskdir/taskdef.go
@@ -31,6 +31,15 @@ type Definition struct {
 	BuilderConfig  api.BuilderConfig  `yaml:"builderConfig,omitempty"`
 	Repo           string             `yaml:"repo,omitempty"`
 	Timeout        int                `yaml:"timeout,omitempty"`
+
+	// Root is a directory path relative to the parent directory of this
+	// task definition which defines what directory should be included
+	// in the task's Docker image.
+	//
+	// If not set, defaults to "." (in other words, the parent directory of this task definition).
+	//
+	// This field is ignored when using the pre-built image builder (aka "manual").
+	Root string `yaml:"root,omitempty"`
 }
 
 func (this Definition) Validate() (Definition, error) {
@@ -66,12 +75,8 @@ func (this Definition) Validate() (Definition, error) {
 	return this, nil
 }
 
-func (this TaskDirectory) DefinitionPath() string {
-	return this.path
-}
-
 func (this TaskDirectory) ReadDefinition() (Definition, error) {
-	buf, err := ioutil.ReadFile(this.path)
+	buf, err := ioutil.ReadFile(this.defPath)
 	if err != nil {
 		return Definition{}, errors.Wrap(err, "reading task definition")
 	}
@@ -90,7 +95,7 @@ func (this TaskDirectory) WriteDefinition(def Definition) error {
 		return errors.Wrap(err, "marshalling definition")
 	}
 
-	if err := ioutil.WriteFile(this.path, data, 0664); err != nil {
+	if err := ioutil.WriteFile(this.defPath, data, 0664); err != nil {
 		return errors.Wrap(err, "writing file")
 	}
 


### PR DESCRIPTION
This allows you to add an optional `root` field to your task definition with a relative directory path (from the parent directory of your task definition) that determines which directory to build your image from.

For example, if your code was laid out like:

```
utils/db.go

taskA/main.go
taskA/airplane.yml

taskB/main.go
taskB/airplane.yml
```

You would be able to set `taskA/airplane.yml` to have `root: "../"` and it would build a Docker image that contains `utils` along with `taskA` and `taskB`, which would allow you to share the `utils` package across both tasks.

Note that other file paths, such as entrypoints, are relative to the root so if you adjust root then make sure to also adjust those filepaths.