### PR TITLE
Fix logger.Log to not use Fprintf if no args

### DIFF
--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -13,7 +13,12 @@ var (
 // Log writes a log message to stderr, followed by a newline. Printf-style
 // formatting is applied to msg using args.
 func Log(msg string, args ...interface{}) {
-	fmt.Fprintf(os.Stderr, msg+"\n", args...)
+	if len(args) == 0 {
+		// Use Fprint if no args - avoids treating msg like a format string
+		fmt.Fprint(os.Stderr, msg+"\n")
+	} else {
+		fmt.Fprintf(os.Stderr, msg+"\n", args...)
+	}
 }
 
 // Debug writes a log message to stderr, followed by a newline, if the CLI

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -25,7 +25,12 @@ func Log(msg string, args ...interface{}) {
 // is executing in debug mode. Printf-style formatting is applied to msg
 // using args.
 func Debug(msg string, args ...interface{}) {
-	if EnableDebug {
+	if !EnableDebug {
+		return
+	}
+	if len(args) == 0 {
+		fmt.Fprint(os.Stderr, msg+"\n")
+	} else {
 		fmt.Fprintf(os.Stderr, msg+"\n", args...)
 	}
 }


### PR DESCRIPTION
This was causing MISSING / NOVERB to be interpolated into messages that
had percent signs, since Go was treating them as format strings.
