### PR TITLE
Fix bug with task definition constraints

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -16,7 +16,7 @@ type CreateTaskRequest struct {
 	Command        []string          `json:"command"`
 	Arguments      []string          `json:"arguments"`
 	Parameters     Parameters        `json:"parameters"`
-	Constraints    Constraints       `json:"constraints"`
+	Constraints    RunConstraints    `json:"constraints"`
 	Env            TaskEnv           `json:"env"`
 	ResourceLimits map[string]string `json:"resourceLimits"`
 	Builder        string            `json:"builder"`
@@ -35,7 +35,7 @@ type UpdateTaskRequest struct {
 	Command        []string          `json:"command" yaml:"command"`
 	Arguments      []string          `json:"arguments" yaml:"arguments"`
 	Parameters     Parameters        `json:"parameters" yaml:"parameters"`
-	Constraints    Constraints       `json:"constraints" yaml:"constraints"`
+	Constraints    RunConstraints    `json:"constraints" yaml:"constraints"`
 	Env            TaskEnv           `json:"env" yaml:"env"`
 	ResourceLimits map[string]string `json:"resourceLimits" yaml:"resourceLimits"`
 	Builder        string            `json:"builder" yaml:"builder"`
@@ -224,7 +224,7 @@ type Task struct {
 	Command        []string       `json:"command" yaml:"command"`
 	Arguments      []string       `json:"arguments" yaml:"arguments"`
 	Parameters     Parameters     `json:"parameters" yaml:"parameters"`
-	Constraints    Constraints    `json:"constraints" yaml:"constraints"`
+	Constraints    RunConstraints `json:"constraints" yaml:"constraints"`
 	Env            TaskEnv        `json:"env" yaml:"env"`
 	ResourceLimits ResourceLimits `json:"resourceLimits" yaml:"resourceLimits"`
 	Builder        string         `json:"builder" yaml:"builder"`

--- a/pkg/taskdir/taskdef.go
+++ b/pkg/taskdir/taskdef.go
@@ -22,7 +22,7 @@ type Definition struct {
 	Command        []string           `yaml:"command,omitempty"`
 	Arguments      []string           `yaml:"arguments,omitempty"`
 	Parameters     api.Parameters     `yaml:"parameters,omitempty"`
-	Constraints    api.Constraints    `yaml:"constraints,omitempty"`
+	Constraints    api.RunConstraints `yaml:"constraints,omitempty"`
 	Env            api.TaskEnv        `yaml:"env,omitempty"`
 	ResourceLimits api.ResourceLimits `yaml:"resourceLimits,omitempty"`
 	Builder        string             `yaml:"builder,omitempty"`


### PR DESCRIPTION
We were using the wrong Constraints type! However, with this change, you'll now be able to manage constraints from a task definition.