### PR TITLE
Add support for uploading to the remote builder

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,9 +11,11 @@ require (
 	github.com/docker/go-connections v0.4.0 // indirect
 	github.com/fatih/color v1.10.0
 	github.com/go-git/go-git/v5 v5.2.0
+	github.com/golang/snappy v0.0.3 // indirect
 	github.com/gosimple/slug v1.9.0
 	github.com/kr/text v0.2.0
 	github.com/mattn/go-isatty v0.0.12
+	github.com/mholt/archiver/v3 v3.5.0
 	github.com/moby/sys/mount v0.2.0 // indirect
 	github.com/morikuni/aec v1.0.0 // indirect
 	github.com/olekukonko/tablewriter v0.0.5
@@ -22,6 +24,7 @@ require (
 	github.com/segmentio/events/v2 v2.4.0
 	github.com/spf13/cobra v1.1.3
 	github.com/stretchr/testify v1.6.1
+	github.com/ulikunitz/xz v0.5.10 // indirect
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	golang.org/x/sys v0.0.0-20210309074719-68d13333faf2 // indirect
 	golang.org/x/text v0.3.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -71,6 +71,8 @@ github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuy
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alexflint/go-filemutex v0.0.0-20171022225611-72bdc8eae2ae/go.mod h1:CgnQgUtFrFz9mxFNtED3jI5tLDjKlOM+oUF/sTk6ps0=
+github.com/andybalholm/brotli v1.0.0 h1:7UCwP93aiSfvWpapti8g88vVVGp2qqtGyePsSuDafo4=
+github.com/andybalholm/brotli v1.0.0/go.mod h1:loMXtMfwqflxFJPmdbJO0a3KNoPuLBgiu3qAvBg8x/Y=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239 h1:kFOfPq6dUM1hTo4JG6LR5AXSUEsOjtdm0kw0FtQtMJA=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
@@ -205,6 +207,9 @@ github.com/docker/go-units v0.4.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDD
 github.com/docker/libtrust v0.0.0-20150114040149-fa567046d9b1/go.mod h1:cyGadeNEkKy96OOhEzfZl+yxihPEzKnqJwvfuSUqbZE=
 github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96/go.mod h1:Qh8CwZgvJUkLughtfhJv5dyTYa91l1fOUCrgjqmcifM=
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
+github.com/dsnet/compress v0.0.1 h1:PlZu0n3Tuv04TzpfPbrnI0HW/YwodEXDS+oPKahKF0Q=
+github.com/dsnet/compress v0.0.1/go.mod h1:Aw8dCMJ7RioblQeTqt88akK31OvO8Dhf5JflhBbQEHo=
+github.com/dsnet/golib v0.0.0-20171103203638-1ea166775780/go.mod h1:Lj+Z9rebOhdfkVLjJ8T6VcRQv3SXugXy999NBtR9aFY=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
@@ -296,6 +301,9 @@ github.com/golang/protobuf v1.4.1/go.mod h1:U8fpvMrcmy5pZrNK1lt4xCsGvpyWQ/VVv6QD
 github.com/golang/protobuf v1.4.2/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
 github.com/golang/protobuf v1.4.3 h1:JjCZWpVbqXDqFVmTfYWEVTMIYrL/NPdPSCHPJ0T/raM=
 github.com/golang/protobuf v1.4.3/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
+github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
+github.com/golang/snappy v0.0.3 h1:fHPg5GQYlCeLIPB9BZqMVR5nR9A+IM5zcgeTdjMYmLA=
+github.com/golang/snappy v0.0.3/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
@@ -390,7 +398,13 @@ github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvW
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
+github.com/klauspost/compress v1.4.1/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0guNDohfE1A=
+github.com/klauspost/compress v1.10.10/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
+github.com/klauspost/compress v1.11.3 h1:dB4Bn0tN3wdCzQxnS8r06kV74qN/TAfaIS0bVE8h3jc=
 github.com/klauspost/compress v1.11.3/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
+github.com/klauspost/cpuid v1.2.0/go.mod h1:Pj4uuM528wm8OyEC2QMXAi2YiTZ96dNQPGgoMS4s3ek=
+github.com/klauspost/pgzip v1.2.4 h1:TQ7CNpYKovDOmqzRHKxJh0BeaBI7UdQZYc6p7pMQh1A=
+github.com/klauspost/pgzip v1.2.4/go.mod h1:Ch1tH69qFZu15pkjo5kYi6mth2Zzwzt50oCQKQE9RUs=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
@@ -426,6 +440,8 @@ github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
 github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b h1:j7+1HpAFS1zy5+Q4qx1fWh90gTKwiN4QCGoY9TWyyO4=
 github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b/go.mod h1:01TrycV0kFyexm33Z7vhZRXopbI8J3TDReVlkTgMUxE=
+github.com/mholt/archiver/v3 v3.5.0 h1:nE8gZIrw66cu4osS/U7UW7YDuGMHssxKutU8IfWxwWE=
+github.com/mholt/archiver/v3 v3.5.0/go.mod h1:qqTTPUK/HZPFgFQ/TJ3BzvTpF/dPtFVJXdQbCmeMxwc=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/mistifyio/go-zfs v2.1.2-0.20190413222219-f784269be439+incompatible/go.mod h1:8AuVvqP/mXw1px98n46wfvcGfQ4ci2FwoAjKYxuo3Z4=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
@@ -459,6 +475,8 @@ github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+
 github.com/ncw/swift v1.0.47/go.mod h1:23YIA4yWVnGwv2dQlN4bB7egfYX6YLn0Yo/S6zZO/ZM=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
+github.com/nwaples/rardecode v1.1.0 h1:vSxaY8vQhOcVr4mm5e8XllHWTiM4JF507A0Katqw7MQ=
+github.com/nwaples/rardecode v1.1.0/go.mod h1:5DzqNKiOdpKKBH87u8VlvAnPZMXcGRhxWkRpHbbfGS0=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/olekukonko/tablewriter v0.0.0-20170122224234-a0225b3f23b5/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
 github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
@@ -506,6 +524,8 @@ github.com/otiai10/mint v1.3.2/go.mod h1:/yxELlJQ0ufhjUwhshSj+wFjZ78CnZ48/1wtmBH
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
+github.com/pierrec/lz4/v4 v4.0.3 h1:vNQKSVZNYUEAvRY9FaUXAF1XPbSOHJtDTiP41kzDz2E=
+github.com/pierrec/lz4/v4 v4.0.3/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1-0.20171018195549-f15c970de5b7/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -605,6 +625,10 @@ github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635/go.mod h1:hkRG
 github.com/tchap/go-patricia v2.2.6+incompatible/go.mod h1:bmLyhP68RS6kStMGxByiQ23RP/odRBOTVjwp2cDyi6I=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
+github.com/ulikunitz/xz v0.5.6/go.mod h1:2bypXElzHzzJZwzH67Y6wb67pO62Rzfn7BSiF4ABRW8=
+github.com/ulikunitz/xz v0.5.7/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
+github.com/ulikunitz/xz v0.5.10 h1:t92gobL9l3HE202wg3rlk19F6X+JOxl9BBrCCMYEYd8=
+github.com/ulikunitz/xz v0.5.10/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
 github.com/urfave/cli v0.0.0-20171014202726-7bc6a0acffa5/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
@@ -620,6 +644,8 @@ github.com/xanzy/ssh-agent v0.2.1/go.mod h1:mLlQY/MoOhWBj+gOGMQkOeiEvkx+8pJSI+0B
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
 github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:GwrjFmJcFw6At/Gs6z4yjiIwzuJ1/+UwLxMQDVQXShQ=
 github.com/xeipuuv/gojsonschema v0.0.0-20180618132009-1d523034197f/go.mod h1:5yf86TLmAcydyeJq5YvxkGPE2fm/u4myDekKRoLuqhs=
+github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 h1:nIPpBwaJSVYIxUFsDv3M8ofmx9yWTog9BfvIu0q41lo=
+github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8/go.mod h1:HUYIGzjTL3rfEspMxjDjgmT5uz5wzYJKVo23qUhYTos=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/pkg/api/client.go
+++ b/pkg/api/client.go
@@ -169,7 +169,7 @@ func (c Client) GetTask(ctx context.Context, slug string) (res Task, err error) 
 
 // UploadBuild creates an Airplane upload and returns metadata about it.
 func (c Client) UploadBuild(ctx context.Context, req UploadBuildRequest) (res Upload, err error) {
-	err = c.do(ctx, "POST", "/builds/upload?", req, &res)
+	err = c.do(ctx, "POST", "/builds/upload", req, &res)
 	return
 }
 

--- a/pkg/api/client.go
+++ b/pkg/api/client.go
@@ -168,7 +168,7 @@ func (c Client) GetTask(ctx context.Context, slug string) (res Task, err error) 
 }
 
 // UploadBuild creates an Airplane upload and returns metadata about it.
-func (c Client) UploadBuild(ctx context.Context, req UploadBuildRequest) (res Upload, err error) {
+func (c Client) UploadBuild(ctx context.Context, req UploadBuildRequest) (res UploadBuildResponse, err error) {
 	err = c.do(ctx, "POST", "/builds/upload", req, &res)
 	return
 }

--- a/pkg/api/client.go
+++ b/pkg/api/client.go
@@ -167,9 +167,9 @@ func (c Client) GetTask(ctx context.Context, slug string) (res Task, err error) 
 	return
 }
 
-// UploadBuild creates an Airplane upload and returns metadata about it.
-func (c Client) UploadBuild(ctx context.Context, req UploadBuildRequest) (res UploadBuildResponse, err error) {
-	err = c.do(ctx, "POST", "/builds/upload", req, &res)
+// CreateBuildUpload creates an Airplane upload and returns metadata about it.
+func (c Client) CreateBuildUpload(ctx context.Context, req CreateBuildUploadRequest) (res CreateBuildUploadResponse, err error) {
+	err = c.do(ctx, "POST", "/builds/createUpload", req, &res)
 	return
 }
 

--- a/pkg/api/client.go
+++ b/pkg/api/client.go
@@ -167,6 +167,12 @@ func (c Client) GetTask(ctx context.Context, slug string) (res Task, err error) 
 	return
 }
 
+// UploadBuild creates an Airplane upload and returns metadata about it.
+func (c Client) UploadBuild(ctx context.Context, req UploadBuildRequest) (res Upload, err error) {
+	err = c.do(ctx, "POST", "/builds/upload?", req, &res)
+	return
+}
+
 // Do sends a request with `method`, `path`, `payload` and `reply`.
 func (c Client) do(ctx context.Context, method, path string, payload, reply interface{}) error {
 	var url = "https://" + c.host() + "/v0" + path

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -295,3 +295,16 @@ type Run struct {
 type ListRunsResponse struct {
 	Runs []Run `json:"runs"`
 }
+
+type UploadBuildRequest struct {
+	FileName string `json:"fileName"`
+	// TODO
+}
+
+type UploadBuildResponse struct {
+	Upload Upload `json:"upload"`
+}
+
+type Upload struct {
+	// TODO
+}

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -296,12 +296,12 @@ type ListRunsResponse struct {
 	Runs []Run `json:"runs"`
 }
 
-type UploadBuildRequest struct {
+type CreateBuildUploadRequest struct {
 	FileName  string `json:"fileName"`
 	SizeBytes int    `json:"sizeBytes"`
 }
 
-type UploadBuildResponse struct {
+type CreateBuildUploadResponse struct {
 	Upload       Upload `json:"upload"`
 	WriteOnlyURL string `json:"writeOnlyURL"`
 }

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -297,14 +297,16 @@ type ListRunsResponse struct {
 }
 
 type UploadBuildRequest struct {
-	FileName string `json:"fileName"`
-	// TODO
+	FileName  string `json:"fileName"`
+	SizeBytes int    `json:"sizeBytes"`
 }
 
 type UploadBuildResponse struct {
-	Upload Upload `json:"upload"`
+	Upload       Upload `json:"upload"`
+	WriteOnlyURL string `json:"writeOnlyURL"`
 }
 
 type Upload struct {
-	// TODO
+	ID  string `json:"id"`
+	URL string `json:"url"`
 }

--- a/pkg/build/builder.go
+++ b/pkg/build/builder.go
@@ -47,7 +47,7 @@ func ToBuilderKind(s string) (BuilderKind, error) {
 	case string(BuilderKindLocal):
 		return BuilderKindLocal, nil
 	case string(BuilderKindRemote):
-		return BuilderKindLocal, nil
+		return BuilderKindRemote, nil
 	default:
 		return BuilderKind(""), errors.Errorf("Unknown builder: %s", s)
 	}

--- a/pkg/build/builder.go
+++ b/pkg/build/builder.go
@@ -31,6 +31,28 @@ type RegistryAuth struct {
 	Repo  string
 }
 
+// BuilderKind represents where the Docker build should take place.
+//
+// For BuilderKindLocal, users need to have Docker installed and running.
+// For BuilderKindRemote, the build will happen on Airplane servers.
+type BuilderKind string
+
+const (
+	BuilderKindLocal  BuilderKind = "local"
+	BuilderKindRemote BuilderKind = "remote"
+)
+
+func ToBuilderKind(s string) (BuilderKind, error) {
+	switch s {
+	case string(BuilderKindLocal):
+		return BuilderKindLocal, nil
+	case string(BuilderKindRemote):
+		return BuilderKindLocal, nil
+	default:
+		return BuilderKind(""), errors.Errorf("Unknown builder: %s", s)
+	}
+}
+
 // Host returns the registry hostname.
 func (r RegistryAuth) host() string {
 	return strings.SplitN(r.Repo, "/", 2)[0]
@@ -38,6 +60,11 @@ func (r RegistryAuth) host() string {
 
 // Config configures a builder.
 type Config struct {
+	// Kind describes how the build should be performed, such as
+	// whether it should use the local Docker daemon or a remote
+	// hosted builder.
+	Kind BuilderKind
+
 	// Root is the root directory.
 	//
 	// It must be an absolute path to the project directory.

--- a/pkg/build/local.go
+++ b/pkg/build/local.go
@@ -1,0 +1,45 @@
+package build
+
+import (
+	"context"
+	"io"
+
+	"github.com/airplanedev/cli/pkg/api"
+	"github.com/airplanedev/cli/pkg/logger"
+	"github.com/airplanedev/cli/pkg/taskdir"
+	"github.com/pkg/errors"
+)
+
+func Local(ctx context.Context, client *api.Client, dir taskdir.TaskDirectory, def taskdir.Definition, taskID string, output io.Writer) error {
+	registry, err := client.GetRegistryToken(ctx)
+	if err != nil {
+		return errors.Wrap(err, "getting registry token")
+	}
+
+	b, err := New(Config{
+		Root:    dir.DefinitionRootPath(),
+		Builder: def.Builder,
+		Args:    Args(def.BuilderConfig),
+		Writer:  output,
+		Auth: &RegistryAuth{
+			Token: registry.Token,
+			Repo:  registry.Repo,
+		},
+	})
+	if err != nil {
+		return errors.Wrap(err, "new build")
+	}
+
+	logger.Log("  Building...")
+	bo, err := b.Build(ctx, taskID, "latest")
+	if err != nil {
+		return errors.Wrap(err, "build")
+	}
+
+	logger.Log("  Updating...")
+	if err := b.Push(ctx, bo.Tag); err != nil {
+		return errors.Wrap(err, "push")
+	}
+
+	return nil
+}

--- a/pkg/build/remote.go
+++ b/pkg/build/remote.go
@@ -57,7 +57,7 @@ func Remote(ctx context.Context, dir taskdir.TaskDirectory, client *api.Client) 
 	}
 
 	// Upload the archive to Airplane:
-	upload, err := client.UploadBuild(ctx, api.UploadBuildRequest{
+	upload, err := client.CreateBuildUpload(ctx, api.CreateBuildUploadRequest{
 		FileName:  archiveName,
 		SizeBytes: sizeBytes,
 	})

--- a/pkg/build/remote.go
+++ b/pkg/build/remote.go
@@ -21,7 +21,7 @@ func Remote(ctx context.Context, dir taskdir.TaskDirectory, client *api.Client) 
 		return errors.Wrap(err, "creating temporary directory for remote build")
 	}
 	logger.Debug("tmpdir: %s", tmpdir)
-	// defer os.RemoveAll(tmpdir)
+	defer os.RemoveAll(tmpdir)
 
 	// Archive the root task directory:
 	// TODO: filter out files/directories that match .dockerignore

--- a/pkg/build/remote.go
+++ b/pkg/build/remote.go
@@ -27,11 +27,10 @@ func Remote(ctx context.Context, dir taskdir.TaskDirectory, client *api.Client) 
 	// TODO: filter out files/directories that match .dockerignore
 	archiveName := "airplane-build.tar.gz"
 	archivePath := path.Join(tmpdir, archiveName)
-	// We want to produce an archive where the contents of the archive
-	// are the files inside of `dir.DefinitionRootPath()`, rather than
-	// a directory containing those files. Therefore, we need to produce
-	// a list of files/directories within the root directory instead of
-	// directly providing mholt/archiver with `dir.DefinitionRootPath()`.
+	// mholt/archiver takes a list of "sources" (files/directories) that will
+	// be included in the root of the archive. In our case, we want the root of
+	// the archive to be the contents of the task directory, rather than the
+	// task directory itself.
 	var sources []string
 	if files, err := ioutil.ReadDir(dir.DefinitionRootPath()); err != nil {
 		return errors.Wrap(err, "inspecting files in task root")

--- a/pkg/build/remote.go
+++ b/pkg/build/remote.go
@@ -1,0 +1,46 @@
+package build
+
+import (
+	"context"
+	"os"
+	"path"
+
+	"github.com/airplanedev/cli/pkg/api"
+	"github.com/airplanedev/cli/pkg/logger"
+	"github.com/airplanedev/cli/pkg/taskdir"
+	"github.com/mholt/archiver/v3"
+	"github.com/pkg/errors"
+)
+
+func Remote(ctx context.Context, dir taskdir.TaskDirectory, client *api.Client) error {
+	tmpdir := os.TempDir()
+	defer os.RemoveAll(tmpdir)
+
+	// Archive the root task directory.
+	archiveName := "airplane-build.tar.gz"
+	archivePath := path.Join(tmpdir, archiveName)
+	// TODO: filter out files/directories that match .dockerignore
+	if err := archiver.Archive([]string{dir.DefinitionRootPath()}, archivePath); err != nil {
+		return errors.Wrap(err, "building archive")
+	}
+
+	// Upload the task directory to Airplane.
+	upload, err := client.UploadBuild(ctx, api.UploadBuildRequest{
+		FileName: archiveName,
+		// TODO: compute this
+		SizeBytes: 0,
+	})
+	if err != nil {
+		return errors.Wrap(err, "creating upload")
+	}
+
+	// TODO: GCS write to that URL
+
+	logger.Debug("Uploaded archive to id=%s at %s", upload.ID, upload.URL)
+
+	// TODO: create the build, referencing this upload
+	// TODO: poll the build until it finishes
+
+	// TODO: once this works e2e, we can remove this error:
+	return errors.New("remote builds not implemented")
+}

--- a/pkg/cmd/tasks/deploy/deploy.go
+++ b/pkg/cmd/tasks/deploy/deploy.go
@@ -39,8 +39,10 @@ func New(c *cli.Config) *cobra.Command {
 	}
 
 	cmd.Flags().StringVarP(&cfg.file, "file", "f", "", "Path to a task definition file.")
-	// TODO: make "remote" as the default once it is implemented.
 	cmd.Flags().StringVar(&cfg.builder, "builder", string(build.BuilderKindLocal), "Where to build the task's Docker image. Accepts: [local, remote]")
+
+	// TODO: make "remote" the default once and un-hide this flag once it is fully implemented.
+	cli.Must(cmd.Flags().MarkHidden("builder"))
 
 	cli.Must(cmd.MarkFlagRequired("file"))
 

--- a/pkg/cmd/tasks/deploy/deploy.go
+++ b/pkg/cmd/tasks/deploy/deploy.go
@@ -194,12 +194,16 @@ func buildRemote(ctx context.Context, dir taskdir.TaskDirectory, client *api.Cli
 	// Upload the task directory to Airplane.
 	upload, err := client.UploadBuild(ctx, api.UploadBuildRequest{
 		FileName: archiveName,
+		// TODO: compute this
+		SizeBytes: 0,
 	})
 	if err != nil {
 		return errors.Wrap(err, "creating upload")
 	}
 
-	logger.Debug("Uploaded archive to: %+v", upload)
+	// TODO: GCS write to that URL
+
+	logger.Debug("Uploaded archive to id=%s at %s", upload.ID, upload.URL)
 
 	// TODO: create the build, referencing this upload
 	// TODO: poll the build until it finishes

--- a/pkg/cmd/tasks/deploy/deploy.go
+++ b/pkg/cmd/tasks/deploy/deploy.go
@@ -40,7 +40,7 @@ func New(c *cli.Config) *cobra.Command {
 
 	cmd.Flags().StringVarP(&cfg.file, "file", "f", "", "Path to a task definition file.")
 	// TODO: make "remote" as the default once it is implemented.
-	cmd.Flags().StringVar(&cfg.file, "builder", string(build.BuilderKindLocal), "Path to a task definition file.")
+	cmd.Flags().StringVar(&cfg.builder, "builder", string(build.BuilderKindLocal), "Where to build the task's Docker image. Accepts: [local, remote]")
 
 	cli.Must(cmd.MarkFlagRequired("file"))
 


### PR DESCRIPTION
This PR adds a new `--builder` flag to the `deploy` command which allows you to toggle between the local builder (via the local Docker daemon) or the remote builder (via the Airplane hosted Docker builder). For now, we default to `--builder=local` since the remote builder isn't live yet.

As for remote building functionality, this PR adds logic for archiving and uploading source code into GCS where it'll be available to our hosted builder. Once it does that, it temporarily errors until the remote builder is ready.

I've left a number of TODO comments that will be addressed in future passes, but let me know if any aren't clear.