### PR TITLE
Wait for hosted build to complete before returning

### DIFF
--- a/pkg/api/client.go
+++ b/pkg/api/client.go
@@ -96,8 +96,8 @@ func (c Client) CreateTask(ctx context.Context, req CreateTaskRequest) (res Crea
 }
 
 // UpdateTask updates a task with the given req.
-func (c Client) UpdateTask(ctx context.Context, req UpdateTaskRequest) (err error) {
-	err = c.do(ctx, "POST", "/tasks/update", req, nil)
+func (c Client) UpdateTask(ctx context.Context, req UpdateTaskRequest) (res UpdateTaskResponse, err error) {
+	err = c.do(ctx, "POST", "/tasks/update", req, &res)
 	return
 }
 

--- a/pkg/api/client.go
+++ b/pkg/api/client.go
@@ -167,6 +167,19 @@ func (c Client) GetTask(ctx context.Context, slug string) (res Task, err error) 
 	return
 }
 
+// GetBuild returns metadata about a hosted build.
+func (c Client) GetBuild(ctx context.Context, id string) (res GetBuildResponse, err error) {
+	q := url.Values{"id": []string{id}}
+	err = c.do(ctx, "GET", "/builds/get?"+q.Encode(), nil, &res)
+	return
+}
+
+// CreateBuild creates an Airplane build and returns metadata about it.
+func (c Client) CreateBuild(ctx context.Context, req CreateBuildRequest) (res CreateBuildResponse, err error) {
+	err = c.do(ctx, "POST", "/builds/create", req, &res)
+	return
+}
+
 // CreateBuildUpload creates an Airplane upload and returns metadata about it.
 func (c Client) CreateBuildUpload(ctx context.Context, req CreateBuildUploadRequest) (res CreateBuildUploadResponse, err error) {
 	err = c.do(ctx, "POST", "/builds/createUpload", req, &res)

--- a/pkg/api/client.go
+++ b/pkg/api/client.go
@@ -167,6 +167,22 @@ func (c Client) GetTask(ctx context.Context, slug string) (res Task, err error) 
 	return
 }
 
+// GetConfig returns a config by name and tag.
+func (c Client) GetConfig(ctx context.Context, name, tag string) (res GetConfigResponse, err error) {
+	q := url.Values{
+		"name": []string{name},
+		"tag":  []string{tag},
+	}
+	err = c.do(ctx, "GET", "/configs/get?"+q.Encode(), nil, &res)
+	return
+}
+
+// SetConfig sets a config, creating it if new and updating it if already exists.
+func (c Client) SetConfig(ctx context.Context, req SetConfigRequest) (err error) {
+	err = c.do(ctx, "POST", "/configs/set", req, nil)
+	return
+}
+
 // GetBuild returns metadata about a hosted build.
 func (c Client) GetBuild(ctx context.Context, id string) (res GetBuildResponse, err error) {
 	q := url.Values{"id": []string{id}}
@@ -183,22 +199,6 @@ func (c Client) CreateBuild(ctx context.Context, req CreateBuildRequest) (res Cr
 // CreateBuildUpload creates an Airplane upload and returns metadata about it.
 func (c Client) CreateBuildUpload(ctx context.Context, req CreateBuildUploadRequest) (res CreateBuildUploadResponse, err error) {
 	err = c.do(ctx, "POST", "/builds/createUpload", req, &res)
-	return
-}
-
-// GetConfig returns a config by name and tag.
-func (c Client) GetConfig(ctx context.Context, name, tag string) (res GetConfigResponse, err error) {
-	q := url.Values{
-		"name": []string{name},
-		"tag":  []string{tag},
-	}
-	err = c.do(ctx, "GET", "/configs/get?"+q.Encode(), nil, &res)
-	return
-}
-
-// SetConfig sets a config, creating it if new and updating it if already exists.
-func (c Client) SetConfig(ctx context.Context, req SetConfigRequest) (err error) {
-	err = c.do(ctx, "POST", "/configs/set", req, nil)
 	return
 }
 

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -301,6 +301,27 @@ type ListRunsResponse struct {
 	Runs []Run `json:"runs"`
 }
 
+// SetConfigRequest represents a set config request.
+type SetConfigRequest struct {
+	Name     string `json:"name"`
+	Tag      string `json:"tag"`
+	Value    string `json:"value"`
+	IsSecret bool   `json:"isSecret"`
+}
+
+// Config represents a config var.
+type Config struct {
+	Name     string `json:"name"`
+	Tag      string `json:"tag"`
+	Value    string `json:"value"`
+	IsSecret bool   `json:"isSecret"`
+}
+
+// GetConfigResponse represents a get config response.
+type GetConfigResponse struct {
+	Config Config `json:"config"`
+}
+
 type GetBuildResponse struct {
 	Build Build `json:"build"`
 }
@@ -351,25 +372,4 @@ type CreateBuildUploadResponse struct {
 type Upload struct {
 	ID  string `json:"id"`
 	URL string `json:"url"`
-}
-
-// SetConfigRequest represents a set config request.
-type SetConfigRequest struct {
-	Name     string `json:"name"`
-	Tag      string `json:"tag"`
-	Value    string `json:"value"`
-	IsSecret bool   `json:"isSecret"`
-}
-
-// Config represents a config var.
-type Config struct {
-	Name     string `json:"name"`
-	Tag      string `json:"tag"`
-	Value    string `json:"value"`
-	IsSecret bool   `json:"isSecret"`
-}
-
-// GetConfigResponse represents a get config response.
-type GetConfigResponse struct {
-	Config Config `json:"config"`
 }

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -335,8 +335,7 @@ func (this BuildStatus) IsDone() bool {
 }
 
 type CreateBuildUploadRequest struct {
-	FileName  string `json:"fileName"`
-	SizeBytes int    `json:"sizeBytes"`
+	SizeBytes int `json:"sizeBytes"`
 }
 
 type CreateBuildUploadResponse struct {

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -296,6 +296,44 @@ type ListRunsResponse struct {
 	Runs []Run `json:"runs"`
 }
 
+type GetBuildResponse struct {
+	Build Build `json:"build"`
+}
+
+type CreateBuildRequest struct {
+	TaskRevisionID string `json:"taskRevisionID"`
+	SourceUploadID string `json:"sourceUploadID"`
+}
+
+type CreateBuildResponse struct {
+	Build Build `json:"build"`
+}
+
+type Build struct {
+	ID             string      `json:"id"`
+	TaskRevisionID string      `json:"taskRevisionID"`
+	Status         BuildStatus `json:"status"`
+	CreatedAt      time.Time   `json:"createdAt"`
+	CreatorID      string      `json:"creatorID"`
+	QueuedAt       *time.Time  `json:"queuedAt"`
+	QueuedBy       *string     `json:"queuedBy"`
+	SourceUploadID string      `json:"sourceUploadID"`
+}
+
+type BuildStatus string
+
+const (
+	BuildNotStarted BuildStatus = "NotStarted"
+	BuildActive     BuildStatus = "Active"
+	BuildSucceeded  BuildStatus = "Succeeded"
+	BuildFailed     BuildStatus = "Failed"
+	BuildCancelled  BuildStatus = "Cancelled"
+)
+
+func (this BuildStatus) IsDone() bool {
+	return this == BuildSucceeded || this == BuildFailed || this == BuildCancelled
+}
+
 type CreateBuildUploadRequest struct {
 	FileName  string `json:"fileName"`
 	SizeBytes int    `json:"sizeBytes"`

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -330,7 +330,7 @@ const (
 	BuildCancelled  BuildStatus = "Cancelled"
 )
 
-func (this BuildStatus) IsDone() bool {
+func (this BuildStatus) Stopped() bool {
 	return this == BuildSucceeded || this == BuildFailed || this == BuildCancelled
 }
 

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -45,6 +45,10 @@ type UpdateTaskRequest struct {
 	Timeout int `json:"timeout" yaml:"timeout"`
 }
 
+type UpdateTaskResponse struct {
+	TaskRevisionID string `json:"taskRevisionID"`
+}
+
 // GetLogsResponse represents a get logs response.
 type GetLogsResponse struct {
 	RunID string    `json:"runID"`
@@ -163,8 +167,9 @@ type AgentLabel struct {
 
 // CreateTaskResponse represents a create task response.
 type CreateTaskResponse struct {
-	TaskID string `json:"taskID"`
-	Slug   string `json:"slug"`
+	TaskID         string `json:"taskID"`
+	Slug           string `json:"slug"`
+	TaskRevisionID string `json:"taskRevisionID"`
 }
 
 // ListTasksResponse represents a list tasks response.

--- a/pkg/build/local.go
+++ b/pkg/build/local.go
@@ -36,7 +36,7 @@ func Local(ctx context.Context, client *api.Client, dir taskdir.TaskDirectory, d
 		return errors.Wrap(err, "build")
 	}
 
-	logger.Log("  Updating...")
+	logger.Log("  Pushing...")
 	if err := b.Push(ctx, bo.Tag); err != nil {
 		return errors.Wrap(err, "push")
 	}

--- a/pkg/build/remote.go
+++ b/pkg/build/remote.go
@@ -16,7 +16,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-func Remote(ctx context.Context, dir taskdir.TaskDirectory, client *api.Client) error {
+func Remote(ctx context.Context, dir taskdir.TaskDirectory, client *api.Client, taskRevisionID string) error {
 	tmpdir, err := ioutil.TempDir("", "airplane-builds-")
 	if err != nil {
 		return errors.Wrap(err, "creating temporary directory for remote build")
@@ -34,7 +34,7 @@ func Remote(ctx context.Context, dir taskdir.TaskDirectory, client *api.Client) 
 	}
 
 	build, err := client.CreateBuild(ctx, api.CreateBuildRequest{
-		TaskRevisionID: "todo",
+		TaskRevisionID: taskRevisionID,
 		SourceUploadID: uploadID,
 	})
 	if err != nil {

--- a/pkg/build/remote.go
+++ b/pkg/build/remote.go
@@ -23,9 +23,32 @@ func Remote(ctx context.Context, dir taskdir.TaskDirectory, client *api.Client) 
 	}
 	defer os.RemoveAll(tmpdir)
 
-	// Archive the root task directory:
-	// TODO: filter out files/directories that match .dockerignore
-	archivePath := path.Join(tmpdir, "airplane-build.tar.gz")
+	archivePath := path.Join(tmpdir, "archive.tar.gz")
+	if err := archiveTaskDir(dir, archivePath); err != nil {
+		return err
+	}
+
+	uploadID, err := uploadArchive(ctx, client, archivePath)
+	if err != nil {
+		return err
+	}
+
+	build, err := client.CreateBuild(ctx, api.CreateBuildRequest{
+		TaskRevisionID: "todo",
+		SourceUploadID: uploadID,
+	})
+	if err != nil {
+		return errors.Wrap(err, "creating build")
+	}
+
+	if err := waitForBuild(ctx, client, build.Build.ID); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func archiveTaskDir(dir taskdir.TaskDirectory, archivePath string) error {
 	// mholt/archiver takes a list of "sources" (files/directories) that will
 	// be included in the root of the archive. In our case, we want the root of
 	// the archive to be the contents of the task directory, rather than the
@@ -38,57 +61,50 @@ func Remote(ctx context.Context, dir taskdir.TaskDirectory, client *api.Client) 
 			sources = append(sources, path.Join(dir.DefinitionRootPath(), f.Name()))
 		}
 	}
+
+	// TODO: filter out files/directories that match .dockerignore
 	if err := archiver.Archive(sources, archivePath); err != nil {
 		return errors.Wrap(err, "building archive")
 	}
 
-	// Compute the size of this archive:
-	var sizeBytes int
+	return nil
+}
+
+func uploadArchive(ctx context.Context, client *api.Client, archivePath string) (string, error) {
 	archive, err := os.OpenFile(archivePath, os.O_RDONLY, 0)
 	if err != nil {
-		return errors.Wrap(err, "opening archive file")
+		return "", errors.Wrap(err, "opening archive file")
 	}
 	defer archive.Close()
-	if info, err := archive.Stat(); err != nil {
-		return errors.Wrap(err, "stat on archive file")
-	} else {
-		sizeBytes = int(info.Size())
-	}
 
-	// Upload the archive to Airplane:
+	info, err := archive.Stat()
+	if err != nil {
+		return "", errors.Wrap(err, "stat on archive file")
+	}
+	sizeBytes := int(info.Size())
+
 	upload, err := client.CreateBuildUpload(ctx, api.CreateBuildUploadRequest{
 		SizeBytes: sizeBytes,
 	})
 	if err != nil {
-		return errors.Wrap(err, "creating upload")
+		return "", errors.Wrap(err, "creating upload")
 	}
 
 	logger.Debug("Uploaded archive to id=%s at url=%s", upload.Upload.ID, upload.Upload.URL)
 
 	req, err := http.NewRequestWithContext(ctx, "PUT", upload.WriteOnlyURL, archive)
 	if err != nil {
-		return errors.Wrap(err, "creating GCS upload request")
+		return "", errors.Wrap(err, "creating GCS upload request")
 	}
 	req.Header.Add("X-Goog-Content-Length-Range", fmt.Sprintf("0,%d", sizeBytes))
+
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		return errors.Wrap(err, "uploading to GCS")
+		return "", errors.Wrap(err, "uploading to GCS")
 	}
 	defer resp.Body.Close()
 
-	build, err := client.CreateBuild(ctx, api.CreateBuildRequest{
-		TaskRevisionID: "todo",
-		SourceUploadID: upload.Upload.ID,
-	})
-	if err != nil {
-		return errors.Wrap(err, "creating build")
-	}
-
-	if err := waitForBuild(ctx, client, build.Build.ID); err != nil {
-		return err
-	}
-
-	return nil
+	return upload.Upload.ID, nil
 }
 
 func waitForBuild(ctx context.Context, client *api.Client, buildID string) error {

--- a/pkg/build/remote.go
+++ b/pkg/build/remote.go
@@ -24,8 +24,7 @@ func Remote(ctx context.Context, dir taskdir.TaskDirectory, client *api.Client) 
 
 	// Archive the root task directory:
 	// TODO: filter out files/directories that match .dockerignore
-	archiveName := "airplane-build.tar.gz"
-	archivePath := path.Join(tmpdir, archiveName)
+	archivePath := path.Join(tmpdir, "airplane-build.tar.gz")
 	// mholt/archiver takes a list of "sources" (files/directories) that will
 	// be included in the root of the archive. In our case, we want the root of
 	// the archive to be the contents of the task directory, rather than the
@@ -57,7 +56,6 @@ func Remote(ctx context.Context, dir taskdir.TaskDirectory, client *api.Client) 
 
 	// Upload the archive to Airplane:
 	upload, err := client.CreateBuildUpload(ctx, api.CreateBuildUploadRequest{
-		FileName:  archiveName,
 		SizeBytes: sizeBytes,
 	})
 	if err != nil {


### PR DESCRIPTION
This PR updates the CLI's remote builder logic to:
1. Create a `build` using the exact task revision that was just created/updated.
2. Attach the upload to that build.
3. Long-poll that build until it has stopped.

I also split the `Remote` function up into a few helper functions to make it more readable.

In order to get the exact task revision for `#1` above, we now update your task before building/pushing.

--

Once this PR merges, remote building from the CLI will work once the backend components launch. We will want do some further polish here down the road though, specifically around surfacing progress and build logs (esp in the case of an error).