### PR TITLE
Add aliases for common commands

### DIFF
--- a/pkg/cmd/auth/login/login.go
+++ b/pkg/cmd/auth/login/login.go
@@ -37,7 +37,7 @@ func run(ctx context.Context, c *cli.Config) error {
 }
 
 var (
-	ErrLoggedOut = errors.New("You are not logged in. To login, run:\n    airplane auth login")
+	ErrLoggedOut = errors.New("You are not logged in. To login, run:\n    airplane login")
 )
 
 func EnsureLoggedIn(ctx context.Context, c *cli.Config) error {

--- a/pkg/cmd/auth/login/login.go
+++ b/pkg/cmd/auth/login/login.go
@@ -18,7 +18,7 @@ func New(c *cli.Config) *cobra.Command {
 		Use:   "login",
 		Short: "Login to Airplane",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return run(cmd.Context(), c)
+			return run(cmd.Root().Context(), c)
 		},
 	}
 	return cmd

--- a/pkg/cmd/auth/logout/logout.go
+++ b/pkg/cmd/auth/logout/logout.go
@@ -15,7 +15,7 @@ func New(c *cli.Config) *cobra.Command {
 		Use:   "logout",
 		Short: "Log out of Airplane",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return run(cmd.Context(), c)
+			return run(cmd.Root().Context(), c)
 		},
 	}
 	return cmd

--- a/pkg/cmd/configs/configs.go
+++ b/pkg/cmd/configs/configs.go
@@ -10,9 +10,10 @@ import (
 
 func New(c *cli.Config) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "configs",
-		Short: "Manage config variables",
-		Long:  "Manage config variables",
+		Use:     "configs",
+		Short:   "Manage config variables",
+		Long:    "Manage config variables",
+		Aliases: []string{"config"},
 		Example: heredoc.Doc(`
 			$ airplane configs set my_database_url postgresql://my_database
 			$ airplane configs get my_config_name

--- a/pkg/cmd/configs/get/get.go
+++ b/pkg/cmd/configs/get/get.go
@@ -18,7 +18,7 @@ func New(c *cli.Config) *cobra.Command {
 		Short: "Get a config variable's value",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return run(cmd.Context(), c, args[0])
+			return run(cmd.Root().Context(), c, args[0])
 		},
 	}
 	cmd.Flags().BoolVar(&secret, "secret", false, "Whether to set config var as a secret")

--- a/pkg/cmd/configs/set/set.go
+++ b/pkg/cmd/configs/set/set.go
@@ -46,7 +46,7 @@ func New(c *cli.Config) *cobra.Command {
 			if len(args) == 2 {
 				value = &args[1]
 			}
-			return run(cmd.Context(), c, args[0], value, secret)
+			return run(cmd.Root().Context(), c, args[0], value, secret)
 		},
 	}
 	cmd.Flags().BoolVar(&secret, "secret", false, "Whether to set config var as a secret")

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -8,6 +8,8 @@ import (
 	"github.com/airplanedev/cli/pkg/api"
 	"github.com/airplanedev/cli/pkg/cli"
 	"github.com/airplanedev/cli/pkg/cmd/auth"
+	"github.com/airplanedev/cli/pkg/cmd/auth/login"
+	"github.com/airplanedev/cli/pkg/cmd/auth/logout"
 	"github.com/airplanedev/cli/pkg/cmd/configs"
 	"github.com/airplanedev/cli/pkg/cmd/runs"
 	"github.com/airplanedev/cli/pkg/cmd/tasks"
@@ -88,6 +90,8 @@ func New() *cobra.Command {
 	cmd.AddCommand(initcmd.New(cfg))
 	cmd.AddCommand(deploy.New(cfg))
 	cmd.AddCommand(execute.New(cfg))
+	cmd.AddCommand(login.New(cfg))
+	cmd.AddCommand(logout.New(cfg))
 
 	// Sub-commands:
 	cmd.AddCommand(auth.New(cfg))

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -11,6 +11,9 @@ import (
 	"github.com/airplanedev/cli/pkg/cmd/configs"
 	"github.com/airplanedev/cli/pkg/cmd/runs"
 	"github.com/airplanedev/cli/pkg/cmd/tasks"
+	"github.com/airplanedev/cli/pkg/cmd/tasks/deploy"
+	"github.com/airplanedev/cli/pkg/cmd/tasks/execute"
+	"github.com/airplanedev/cli/pkg/cmd/tasks/initcmd"
 	"github.com/airplanedev/cli/pkg/cmd/version"
 	"github.com/airplanedev/cli/pkg/conf"
 	"github.com/airplanedev/cli/pkg/logger"
@@ -31,11 +34,11 @@ func New() *cobra.Command {
 		Use:   "airplane <command>",
 		Short: "Airplane CLI",
 		Example: heredoc.Doc(`
-		airplane tasks deploy -f ./task.yml
-		airplane tasks execute my_task
+		airplane deploy -f ./task.yml
+		airplane execute my_task
 
-		airplane tasks deploy -f github.com/airplanedev/examples/node/hello-world-javascript/airplane.yml
-		airplane tasks execute hello_world
+		airplane deploy -f github.com/airplanedev/examples/node/hello-world-javascript/airplane.yml
+		airplane execute hello_world
 		`),
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			if c, err := conf.ReadDefault(); err == nil {
@@ -81,7 +84,12 @@ func New() *cobra.Command {
 	cmd.PersistentFlags().BoolVar(&cfg.DebugMode, "debug", false, "Whether to produce debugging output.")
 	cmd.PersistentFlags().BoolVarP(&cfg.Version, "version", "v", false, "Print the CLI version.")
 
-	// Sub-commands.
+	// Aliases for popular namespaced commands:
+	cmd.AddCommand(initcmd.New(cfg))
+	cmd.AddCommand(deploy.New(cfg))
+	cmd.AddCommand(execute.New(cfg))
+
+	// Sub-commands:
 	cmd.AddCommand(auth.New(cfg))
 	cmd.AddCommand(configs.New(cfg))
 	cmd.AddCommand(tasks.New(cfg))

--- a/pkg/cmd/runs/get/get.go
+++ b/pkg/cmd/runs/get/get.go
@@ -21,7 +21,7 @@ func New(c *cli.Config) *cobra.Command {
 		`),
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return run(cmd.Context(), c, args[0])
+			return run(cmd.Root().Context(), c, args[0])
 		},
 	}
 	return cmd

--- a/pkg/cmd/runs/list/list.go
+++ b/pkg/cmd/runs/list/list.go
@@ -22,7 +22,7 @@ func New(c *cli.Config) *cobra.Command {
 			airplane runs list --task my-task -o json
 		`),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return run(cmd.Context(), c, slug)
+			return run(cmd.Root().Context(), c, slug)
 		},
 	}
 

--- a/pkg/cmd/runs/runs.go
+++ b/pkg/cmd/runs/runs.go
@@ -15,9 +15,10 @@ import (
 // New returns a new cobra command.
 func New(c *cli.Config) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "runs",
-		Short: "Manage runs",
-		Long:  "Manage runs",
+		Use:     "runs",
+		Short:   "Manage runs",
+		Long:    "Manage runs",
+		Aliases: []string{"run"},
 		Example: heredoc.Doc(`
 			airplane runs list --task my-task
 			airplane runs get <id>

--- a/pkg/cmd/runs/runs.go
+++ b/pkg/cmd/runs/runs.go
@@ -1,8 +1,6 @@
 package runs
 
 import (
-	"context"
-
 	"github.com/MakeNowJust/heredoc"
 	"github.com/airplanedev/cli/pkg/cli"
 	"github.com/airplanedev/cli/pkg/cmd/auth/login"
@@ -24,7 +22,7 @@ func New(c *cli.Config) *cobra.Command {
 			airplane runs get <id>
 		`),
 		PersistentPreRunE: utils.WithParentPersistentPreRunE(func(cmd *cobra.Command, args []string) error {
-			return login.EnsureLoggedIn(context.TODO(), c)
+			return login.EnsureLoggedIn(cmd.Root().Context(), c)
 		}),
 	}
 

--- a/pkg/cmd/tasks/deploy/deploy.go
+++ b/pkg/cmd/tasks/deploy/deploy.go
@@ -11,8 +11,10 @@ import (
 	"github.com/airplanedev/cli/pkg/api"
 	"github.com/airplanedev/cli/pkg/build"
 	"github.com/airplanedev/cli/pkg/cli"
+	"github.com/airplanedev/cli/pkg/cmd/auth/login"
 	"github.com/airplanedev/cli/pkg/logger"
 	"github.com/airplanedev/cli/pkg/taskdir"
+	"github.com/airplanedev/cli/pkg/utils"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -34,8 +36,11 @@ func New(c *cli.Config) *cobra.Command {
 			airplane tasks deploy -f my-task.yml
 		`),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return run(cmd.Context(), cfg)
+			return run(cmd.Root().Context(), cfg)
 		},
+		PersistentPreRunE: utils.WithParentPersistentPreRunE(func(cmd *cobra.Command, args []string) error {
+			return login.EnsureLoggedIn(cmd.Root().Context(), c)
+		}),
 	}
 
 	cmd.Flags().StringVarP(&cfg.file, "file", "f", "", "Path to a task definition file.")

--- a/pkg/cmd/tasks/deploy/deploy.go
+++ b/pkg/cmd/tasks/deploy/deploy.go
@@ -140,7 +140,7 @@ func run(ctx context.Context, cfg config) error {
 	}
 
 	logger.Log("  Done!")
-	cmd := fmt.Sprintf("airplane tasks execute %s", def.Slug)
+	cmd := fmt.Sprintf("airplane execute %s", def.Slug)
 	if len(def.Parameters) > 0 {
 		cmd += " -- [parameters]"
 	}

--- a/pkg/cmd/tasks/execute/execute.go
+++ b/pkg/cmd/tasks/execute/execute.go
@@ -9,8 +9,10 @@ import (
 	"github.com/MakeNowJust/heredoc"
 	"github.com/airplanedev/cli/pkg/api"
 	"github.com/airplanedev/cli/pkg/cli"
+	"github.com/airplanedev/cli/pkg/cmd/auth/login"
 	"github.com/airplanedev/cli/pkg/logger"
 	"github.com/airplanedev/cli/pkg/print"
+	"github.com/airplanedev/cli/pkg/utils"
 	"github.com/fatih/color"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -41,10 +43,13 @@ func New(c *cli.Config) *cobra.Command {
 			airplane tasks execute <slug> -- [parameters]
 		`),
 		Args: cobra.MinimumNArgs(1),
+		PersistentPreRunE: utils.WithParentPersistentPreRunE(func(cmd *cobra.Command, args []string) error {
+			return login.EnsureLoggedIn(cmd.Root().Context(), c)
+		}),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg.slug = args[0]
 			cfg.args = args[1:]
-			return run(cmd.Context(), cfg)
+			return run(cmd.Root().Context(), cfg)
 		},
 	}
 

--- a/pkg/cmd/tasks/get/get.go
+++ b/pkg/cmd/tasks/get/get.go
@@ -21,7 +21,7 @@ func New(c *cli.Config) *cobra.Command {
 		`),
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return run(cmd.Context(), c, args[0])
+			return run(cmd.Root().Context(), c, args[0])
 		},
 	}
 	return cmd

--- a/pkg/cmd/tasks/initcmd/init.go
+++ b/pkg/cmd/tasks/initcmd/init.go
@@ -11,7 +11,9 @@ import (
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/MakeNowJust/heredoc"
 	"github.com/airplanedev/cli/pkg/cli"
+	"github.com/airplanedev/cli/pkg/cmd/auth/login"
 	"github.com/airplanedev/cli/pkg/logger"
+	"github.com/airplanedev/cli/pkg/utils"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -33,8 +35,11 @@ func New(c *cli.Config) *cobra.Command {
 			$ airplane tasks init -f ./airplane.yml
 			$ airplane tasks init --from hello_world
 		`),
+		PersistentPreRunE: utils.WithParentPersistentPreRunE(func(cmd *cobra.Command, args []string) error {
+			return login.EnsureLoggedIn(cmd.Root().Context(), c)
+		}),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return run(cmd.Context(), cfg)
+			return run(cmd.Root().Context(), cfg)
 		},
 	}
 

--- a/pkg/cmd/tasks/list/list.go
+++ b/pkg/cmd/tasks/list/list.go
@@ -21,7 +21,7 @@ func New(c *cli.Config) *cobra.Command {
 			airplane tasks list -o json
 		`),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return run(cmd.Context(), c)
+			return run(cmd.Root().Context(), c)
 		},
 	}
 	return cmd

--- a/pkg/cmd/tasks/tasks.go
+++ b/pkg/cmd/tasks/tasks.go
@@ -18,9 +18,10 @@ import (
 // New returns a new cobra command.
 func New(c *cli.Config) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "tasks",
-		Short: "Manage tasks",
-		Long:  "Manage tasks",
+		Use:     "tasks",
+		Short:   "Manage tasks",
+		Long:    "Manage tasks",
+		Aliases: []string{"task"},
 		Example: heredoc.Doc(`
 			airplane tasks init
 			airplane tasks deploy -f mytask.yml

--- a/pkg/cmd/tasks/tasks.go
+++ b/pkg/cmd/tasks/tasks.go
@@ -1,8 +1,6 @@
 package tasks
 
 import (
-	"context"
-
 	"github.com/MakeNowJust/heredoc"
 	"github.com/airplanedev/cli/pkg/cli"
 	"github.com/airplanedev/cli/pkg/cmd/auth/login"
@@ -29,7 +27,7 @@ func New(c *cli.Config) *cobra.Command {
 			airplane tasks execute my_task
 		`),
 		PersistentPreRunE: utils.WithParentPersistentPreRunE(func(cmd *cobra.Command, args []string) error {
-			return login.EnsureLoggedIn(context.TODO(), c)
+			return login.EnsureLoggedIn(cmd.Root().Context(), c)
 		}),
 	}
 

--- a/pkg/cmd/version/version.go
+++ b/pkg/cmd/version/version.go
@@ -21,7 +21,7 @@ func New(c *cli.Config) *cobra.Command {
 		Short: "Print the CLI version",
 		Long:  "Print the CLI version",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return run(cmd.Context())
+			return run(cmd.Root().Context())
 		},
 	}
 


### PR DESCRIPTION
This PR adds aliases for the following commands:

- `airplane init` == `airplane tasks init`
- `airplane deploy` == `airplane tasks deploy`
- `airplane execute` == `airplane tasks execute`
- `airplane login` == `airplane auth login`
- `airplane logout` == `airplane auth logout`

It also adds singular aliases for each plural namespace (`configs`, `tasks`, `runs`) so that you can run the following:

```
airplane task deploy ...
```