### PR TITLE
Add `auth info` command to retrieve current user and team

### DIFF
--- a/pkg/api/client.go
+++ b/pkg/api/client.go
@@ -83,6 +83,12 @@ func (c Client) TaskURL(id string) string {
 	return u.String()
 }
 
+// AuthInfo responds with the currently authenticated details.
+func (c Client) AuthInfo(ctx context.Context) (res AuthInfoResponse, err error) {
+	err = c.do(ctx, "GET", "/auth/info", nil, &res)
+	return
+}
+
 // GetRegistryToken responds with the registry token.
 func (c Client) GetRegistryToken(ctx context.Context) (res RegistryTokenResponse, err error) {
 	err = c.do(ctx, "POST", "/registry/getToken", nil, &res)

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -165,6 +165,22 @@ type AgentLabel struct {
 	Value string `json:"value" yaml:"value"`
 }
 
+// AuthInfoResponse represents info about authenticated user.
+type AuthInfoResponse struct {
+	User *UserInfo `json:"user"`
+	Team *TeamInfo `json:"team"`
+}
+
+type UserInfo struct {
+	ID    string `json:"id"`
+	Email string `json:"email"`
+}
+
+type TeamInfo struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
 // CreateTaskResponse represents a create task response.
 type CreateTaskResponse struct {
 	TaskID         string `json:"taskID"`

--- a/pkg/cmd/auth/auth.go
+++ b/pkg/cmd/auth/auth.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"github.com/MakeNowJust/heredoc"
 	"github.com/airplanedev/cli/pkg/cli"
+	"github.com/airplanedev/cli/pkg/cmd/auth/info"
 	"github.com/airplanedev/cli/pkg/cmd/auth/login"
 	"github.com/airplanedev/cli/pkg/cmd/auth/logout"
 	"github.com/spf13/cobra"
@@ -19,6 +20,7 @@ func New(c *cli.Config) *cobra.Command {
 		`),
 	}
 
+	cmd.AddCommand(info.New(c))
 	cmd.AddCommand(login.New(c))
 	cmd.AddCommand(logout.New(c))
 

--- a/pkg/cmd/auth/info/info.go
+++ b/pkg/cmd/auth/info/info.go
@@ -11,6 +11,7 @@ import (
 
 var (
 	blue = color.New(color.FgHiBlue).SprintFunc()
+	gray = color.New(color.FgHiBlack).SprintFunc()
 )
 
 func New(c *cli.Config) *cobra.Command {
@@ -34,7 +35,7 @@ func run(ctx context.Context, c *cli.Config) error {
 
 	var userStr string
 	if res.User == nil {
-		userStr = "no user"
+		userStr = gray("<no user>")
 	} else {
 		userStr = res.User.Email
 	}

--- a/pkg/cmd/auth/info/info.go
+++ b/pkg/cmd/auth/info/info.go
@@ -1,0 +1,45 @@
+package info
+
+import (
+	"context"
+
+	"github.com/airplanedev/cli/pkg/cli"
+	"github.com/airplanedev/cli/pkg/logger"
+	"github.com/fatih/color"
+	"github.com/spf13/cobra"
+)
+
+var (
+	blue = color.New(color.FgHiBlue).SprintFunc()
+)
+
+func New(c *cli.Config) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "info",
+		Short: "Get information about the currently logged in user / team",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return run(cmd.Context(), c)
+		},
+	}
+	return cmd
+}
+
+func run(ctx context.Context, c *cli.Config) error {
+	var client = c.Client
+
+	res, err := client.AuthInfo(ctx)
+	if err != nil {
+		return err
+	}
+
+	var userStr string
+	if res.User == nil {
+		userStr = "no user"
+	} else {
+		userStr = res.User.Email
+	}
+	logger.Log("  Signed in as %s", blue(userStr))
+	logger.Log("  Using team %s (ID: %s)", blue(res.Team.Name), res.Team.ID)
+
+	return nil
+}


### PR DESCRIPTION
$ airplane auth info
  Signed in as josh@airplane.dev
  Using team Airplane (ID: 1jq9NDeTcTmyqqXAjEsk7V0wXaV)
