### PR TITLE
Support -f from execute command, instead of just slug

### DIFF
--- a/pkg/cmd/tasks/execute/execute.go
+++ b/pkg/cmd/tasks/execute/execute.go
@@ -12,6 +12,7 @@ import (
 	"github.com/airplanedev/cli/pkg/cmd/auth/login"
 	"github.com/airplanedev/cli/pkg/logger"
 	"github.com/airplanedev/cli/pkg/print"
+	"github.com/airplanedev/cli/pkg/taskdir"
 	"github.com/airplanedev/cli/pkg/utils"
 	"github.com/fatih/color"
 	"github.com/pkg/errors"
@@ -28,6 +29,7 @@ type config struct {
 	root *cli.Config
 	slug string
 	args []string
+	file string
 }
 
 // New returns a new execute cobra command.
@@ -39,19 +41,33 @@ func New(c *cli.Config) *cobra.Command {
 		Short: "Execute a task",
 		Long:  "Execute a task by its slug with the provided parameters.",
 		Example: heredoc.Doc(`
-			airplane tasks execute echo -- --name value
-			airplane tasks execute <slug> -- [parameters]
+			airplane execute -f ./airplane.yml [-- <parameters...>]
+			airplane execute hello_world [-- <parameters...>]
 		`),
-		Args: cobra.MinimumNArgs(1),
 		PersistentPreRunE: utils.WithParentPersistentPreRunE(func(cmd *cobra.Command, args []string) error {
 			return login.EnsureLoggedIn(cmd.Root().Context(), c)
 		}),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cfg.slug = args[0]
-			cfg.args = args[1:]
+			n := cmd.Flags().ArgsLenAtDash()
+			if n > 1 {
+				return errors.Errorf("at most one arg expected, got: %d", n)
+			}
+
+			// If a '--' was used, then we have 0 or more args to pass to the task.
+			if n != -1 {
+				cfg.args = args[n:]
+			}
+
+			// If an arg was passed, before the --, then it is a task slug to run.
+			if len(args) > 0 && n != 0 {
+				cfg.slug = args[0]
+			}
+
 			return run(cmd.Root().Context(), cfg)
 		},
 	}
+
+	cmd.Flags().StringVarP(&cfg.file, "file", "f", "", "Path to a task definition file.")
 
 	return cmd
 }
@@ -60,7 +76,28 @@ func New(c *cli.Config) *cobra.Command {
 func run(ctx context.Context, cfg config) error {
 	var client = cfg.root.Client
 
-	task, err := client.GetTask(ctx, cfg.slug)
+	slug := cfg.slug
+	if slug == "" {
+		if cfg.file == "" {
+			return errors.New("expected either a task slug or --file")
+		}
+
+		dir, err := taskdir.Open(cfg.file)
+		if err != nil {
+			return err
+		}
+		defer dir.Close()
+		def, err := dir.ReadDefinition()
+		if err != nil {
+			return err
+		}
+		if def.Slug == "" {
+			return errors.Errorf("no task slug found in task definition at %s", cfg.file)
+		}
+		slug = def.Slug
+	}
+
+	task, err := client.GetTask(ctx, slug)
 	if err != nil {
 		return errors.Wrap(err, "get task")
 	}

--- a/pkg/cmd/tasks/execute/execute.go
+++ b/pkg/cmd/tasks/execute/execute.go
@@ -58,7 +58,7 @@ func New(c *cli.Config) *cobra.Command {
 				cfg.args = args[n:]
 			}
 
-			// If an arg was passed, before the --, then it is a task slug to run.
+			// If an arg was passed, before the --, then it is a task slug to execute.
 			if len(args) > 0 && n != 0 {
 				cfg.slug = args[0]
 			}
@@ -87,13 +87,16 @@ func run(ctx context.Context, cfg config) error {
 			return err
 		}
 		defer dir.Close()
+
 		def, err := dir.ReadDefinition()
 		if err != nil {
 			return err
 		}
+
 		if def.Slug == "" {
 			return errors.Errorf("no task slug found in task definition at %s", cfg.file)
 		}
+
 		slug = def.Slug
 	}
 


### PR DESCRIPTION
Since we wrote the `execute` command, we've started storing the task slug in the task definition. This means you can now just point `execute` at your task definition and it can figure out what task to execute. This means that the `deploy` command and `execute` command now feel more similar to each other (🙌🏻 ).

All of these are now valid:

```
airplane execute -f airplane.yml
airplane execute -f airplane.yml -- --name=Colin
airplane execute hello_world
airplane execute hello_world -- --name=Colin
```

I expect the former will be more common when you have a local task definition, and the latter will be more common when you are executing a task that you don't have a local task definition for.