### PR TITLE
Update printed example to `airplane deploy`

### DIFF
--- a/pkg/cmd/tasks/initcmd/sample.go
+++ b/pkg/cmd/tasks/initcmd/sample.go
@@ -85,7 +85,7 @@ func initFromSample(cfg config) error {
 An Airplane task definition for '%s' has been created!
 
 To deploy it to Airplane, run:
-  airplane tasks deploy -f %s`, def.Name, file)
+  airplane deploy -f %s`, def.Name, file)
 
 	return nil
 }

--- a/pkg/cmd/tasks/initcmd/task.go
+++ b/pkg/cmd/tasks/initcmd/task.go
@@ -60,7 +60,7 @@ func initFromTask(ctx context.Context, cfg config) error {
 An Airplane task definition for '%s' has been created!
 
 To deploy it to Airplane, run:
-  airplane tasks deploy -f %s`, task.Name, file)
+  airplane deploy -f %s`, task.Name, file)
 
 	return nil
 }


### PR DESCRIPTION
Instead of `tasks deploy` it's just `deploy`
