### PR TITLE
Fix logger colors to support format strings

### DIFF
--- a/pkg/logger/colors.go
+++ b/pkg/logger/colors.go
@@ -3,10 +3,10 @@ package logger
 import "github.com/fatih/color"
 
 var (
-	Gray   = color.New(color.FgHiBlack).SprintFunc()
-	Blue   = color.New(color.FgHiBlue).SprintFunc()
-	Red    = color.New(color.FgHiRed).SprintFunc()
-	Yellow = color.New(color.FgHiYellow).SprintFunc()
-	Green  = color.New(color.FgHiGreen).SprintFunc()
-	Bold   = color.New(color.Bold).SprintFunc()
+	Gray   = color.New(color.FgHiBlack).SprintfFunc()
+	Blue   = color.New(color.FgHiBlue).SprintfFunc()
+	Red    = color.New(color.FgHiRed).SprintfFunc()
+	Yellow = color.New(color.FgHiYellow).SprintfFunc()
+	Green  = color.New(color.FgHiGreen).SprintfFunc()
+	Bold   = color.New(color.Bold).SprintfFunc()
 )

--- a/pkg/logger/colors.go
+++ b/pkg/logger/colors.go
@@ -1,23 +1,12 @@
 package logger
 
-import (
-	"fmt"
-
-	"github.com/fatih/color"
-)
+import "github.com/fatih/color"
 
 var (
-	Gray   = ColorSprintfFunc(color.FgHiBlack)
-	Blue   = ColorSprintfFunc(color.FgHiBlue)
-	Red    = ColorSprintfFunc(color.FgHiRed)
-	Yellow = ColorSprintfFunc(color.FgHiYellow)
-	Green  = ColorSprintfFunc(color.FgHiGreen)
-	Bold   = ColorSprintfFunc(color.Bold)
+	Gray   = color.New(color.FgHiBlack).SprintFunc()
+	Blue   = color.New(color.FgHiBlue).SprintFunc()
+	Red    = color.New(color.FgHiRed).SprintFunc()
+	Yellow = color.New(color.FgHiYellow).SprintFunc()
+	Green  = color.New(color.FgHiGreen).SprintFunc()
+	Bold   = color.New(color.Bold).SprintFunc()
 )
-
-func ColorSprintfFunc(c color.Attribute) func(msg string, args ...interface{}) string {
-	colorSprint := color.New(c).SprintFunc()
-	return func(msg string, args ...interface{}) string {
-		return colorSprint(fmt.Sprintf(msg, args...))
-	}
-}

--- a/pkg/logger/colors.go
+++ b/pkg/logger/colors.go
@@ -1,12 +1,23 @@
 package logger
 
-import "github.com/fatih/color"
+import (
+	"fmt"
+
+	"github.com/fatih/color"
+)
 
 var (
-	Gray   = color.New(color.FgHiBlack).SprintFunc()
-	Blue   = color.New(color.FgHiBlue).SprintFunc()
-	Red    = color.New(color.FgHiRed).SprintFunc()
-	Yellow = color.New(color.FgHiYellow).SprintFunc()
-	Green  = color.New(color.FgHiGreen).SprintFunc()
-	Bold   = color.New(color.Bold).SprintFunc()
+	Gray   = ColorSprintfFunc(color.FgHiBlack)
+	Blue   = ColorSprintfFunc(color.FgHiBlue)
+	Red    = ColorSprintfFunc(color.FgHiRed)
+	Yellow = ColorSprintfFunc(color.FgHiYellow)
+	Green  = ColorSprintfFunc(color.FgHiGreen)
+	Bold   = ColorSprintfFunc(color.Bold)
 )
+
+func ColorSprintfFunc(c color.Attribute) func(msg string, args ...interface{}) string {
+	colorSprint := color.New(c).SprintFunc()
+	return func(msg string, args ...interface{}) string {
+		return colorSprint(fmt.Sprintf(msg, args...))
+	}
+}


### PR DESCRIPTION
You can now call `logger.Gray("hello %s", "world")` properly.
