### PR TITLE
Add prompt to create missing configs when running `deploy`

### DIFF
--- a/pkg/build/local.go
+++ b/pkg/build/local.go
@@ -30,13 +30,13 @@ func Local(ctx context.Context, client *api.Client, dir taskdir.TaskDirectory, d
 		return errors.Wrap(err, "new build")
 	}
 
-	logger.Log("  Building...")
+	logger.Log("Building...")
 	bo, err := b.Build(ctx, taskID, "latest")
 	if err != nil {
 		return errors.Wrap(err, "build")
 	}
 
-	logger.Log("  Pushing...")
+	logger.Log("Pushing...")
 	if err := b.Push(ctx, bo.Tag); err != nil {
 		return errors.Wrap(err, "push")
 	}

--- a/pkg/cmd/tasks/deploy/deploy.go
+++ b/pkg/cmd/tasks/deploy/deploy.go
@@ -86,7 +86,7 @@ func run(ctx context.Context, cfg config) error {
 	task, err := client.GetTask(ctx, def.Slug)
 	if err == nil {
 		// This task already exists, so we update it:
-		logger.Log("  Updating task...")
+		logger.Log("Updating task...")
 		res, err := client.UpdateTask(ctx, api.UpdateTaskRequest{
 			Slug:           def.Slug,
 			Name:           def.Name,
@@ -111,7 +111,7 @@ func run(ctx context.Context, cfg config) error {
 		taskRevisionID = res.TaskRevisionID
 	} else if aerr, ok := err.(api.Error); ok && aerr.Code == 404 {
 		// A task with this slug does not exist, so we should create one.
-		logger.Log("  Creating task...")
+		logger.Log("Creating task...")
 		res, err := client.CreateTask(ctx, api.CreateTaskRequest{
 			Slug:           def.Slug,
 			Name:           def.Name,
@@ -155,7 +155,7 @@ func run(ctx context.Context, cfg config) error {
 		}
 	}
 
-	logger.Log("  Done!")
+	logger.Log("Done!")
 	cmd := fmt.Sprintf("airplane execute %s", def.Slug)
 	if len(def.Parameters) > 0 {
 		cmd += " -- [parameters]"

--- a/pkg/cmd/tasks/deploy/deploy.go
+++ b/pkg/cmd/tasks/deploy/deploy.go
@@ -77,12 +77,16 @@ func run(ctx context.Context, cfg config) error {
 		return err
 	}
 
+	if err := predeployHooks(ctx, client, def); err != nil {
+		return err
+	}
+
 	var taskID string
 	var taskRevisionID string
 	task, err := client.GetTask(ctx, def.Slug)
 	if err == nil {
 		// This task already exists, so we update it:
-		logger.Log("Updating...")
+		logger.Log("  Updating task...")
 		res, err := client.UpdateTask(ctx, api.UpdateTaskRequest{
 			Slug:           def.Slug,
 			Name:           def.Name,
@@ -107,7 +111,7 @@ func run(ctx context.Context, cfg config) error {
 		taskRevisionID = res.TaskRevisionID
 	} else if aerr, ok := err.(api.Error); ok && aerr.Code == 404 {
 		// A task with this slug does not exist, so we should create one.
-		logger.Log("Creating...")
+		logger.Log("  Creating task...")
 		res, err := client.CreateTask(ctx, api.CreateTaskRequest{
 			Slug:           def.Slug,
 			Name:           def.Name,
@@ -151,7 +155,7 @@ func run(ctx context.Context, cfg config) error {
 		}
 	}
 
-	logger.Log("Done!")
+	logger.Log("  Done!")
 	cmd := fmt.Sprintf("airplane execute %s", def.Slug)
 	if len(def.Parameters) > 0 {
 		cmd += " -- [parameters]"

--- a/pkg/cmd/tasks/deploy/deploy.go
+++ b/pkg/cmd/tasks/deploy/deploy.go
@@ -77,7 +77,7 @@ func run(ctx context.Context, cfg config) error {
 		return err
 	}
 
-	if err := predeployHooks(ctx, client, def); err != nil {
+	if err := ensureConfigsExist(ctx, client, def); err != nil {
 		return err
 	}
 

--- a/pkg/cmd/tasks/deploy/predeploy.go
+++ b/pkg/cmd/tasks/deploy/predeploy.go
@@ -1,0 +1,80 @@
+package deploy
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/AlecAivazis/survey/v2"
+	"github.com/airplanedev/cli/pkg/api"
+	"github.com/airplanedev/cli/pkg/configs"
+	"github.com/airplanedev/cli/pkg/logger"
+	"github.com/airplanedev/cli/pkg/taskdir"
+	"github.com/airplanedev/cli/pkg/utils"
+	"github.com/pkg/errors"
+)
+
+// predeployHooks runs before a task is deployed and can e.g. prompt the user to specify or fix things
+func predeployHooks(ctx context.Context, client *api.Client, def taskdir.Definition) error {
+	// Check if configs exist
+	for k, v := range def.Env {
+		if v.Config != "" {
+			if err := ensureConfigExists(ctx, client, k, v.Config); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func ensureConfigExists(ctx context.Context, client *api.Client, envName, configName string) error {
+	cn, err := configs.ParseName(configName)
+	if err != nil {
+		return err
+	}
+	_, err = client.GetConfig(ctx, cn.Name, cn.Tag)
+	if err == nil {
+		return nil
+	}
+	switch err := errors.Cause(err).(type) {
+	case api.Error:
+		if err.Code != 404 {
+			return err
+		}
+		if !utils.CanPrompt() {
+			return errors.Errorf("config %s does not exist", configName)
+		}
+		logger.Log("Your task definition references config %s, which does not exist", logger.Bold(configName))
+		confirmed, errc := utils.Confirm("Create it now?")
+		if errc != nil {
+			return errc
+		}
+		if !confirmed {
+			return errors.Errorf("config %s does not exist", configName)
+		}
+		return createConfig(ctx, client, cn)
+	default:
+		return err
+	}
+}
+
+func createConfig(ctx context.Context, client *api.Client, cn configs.NameTag) error {
+	// TODO: create a config here
+	var secret bool
+	if err := survey.AskOne(
+		&survey.Confirm{
+			Message: "Is this config a secret?",
+			Help:    "Secret config values are not shown to users",
+			Default: false,
+		},
+		&secret,
+		survey.WithStdio(os.Stdin, os.Stderr, os.Stderr),
+	); err != nil {
+		return errors.Wrap(err, "prompting value")
+	}
+	value, err := configs.ReadValueFromPrompt(fmt.Sprintf("Value for %s", configs.JoinName(cn)), secret)
+	if err != nil {
+		return err
+	}
+	return configs.SetConfig(ctx, client, cn, value, secret)
+}

--- a/pkg/cmd/tasks/deploy/predeploy.go
+++ b/pkg/cmd/tasks/deploy/predeploy.go
@@ -59,7 +59,6 @@ func ensureConfigExists(ctx context.Context, client *api.Client, envName, config
 }
 
 func createConfig(ctx context.Context, client *api.Client, cn configs.NameTag) error {
-	// TODO: create a config here
 	var secret bool
 	if err := survey.AskOne(
 		&survey.Confirm{

--- a/pkg/cmd/tasks/deploy/predeploy.go
+++ b/pkg/cmd/tasks/deploy/predeploy.go
@@ -14,8 +14,8 @@ import (
 	"github.com/pkg/errors"
 )
 
-// predeployHooks runs before a task is deployed and can e.g. prompt the user to specify or fix things
-func predeployHooks(ctx context.Context, client *api.Client, def taskdir.Definition) error {
+// ensureConfigsExist checks for config references in env and asks users to create any missing ones
+func ensureConfigsExist(ctx context.Context, client *api.Client, def taskdir.Definition) error {
 	// Check if configs exist
 	for k, v := range def.Env {
 		if v.Config != "" {

--- a/pkg/configs/configs.go
+++ b/pkg/configs/configs.go
@@ -24,3 +24,11 @@ func ParseName(nameTag string) (NameTag, error) {
 	}
 	return res, nil
 }
+
+func JoinName(nameTag NameTag) string {
+	var tagStr string
+	if nameTag.Tag != "" {
+		tagStr = ":" + nameTag.Tag
+	}
+	return nameTag.Name + tagStr
+}

--- a/pkg/configs/prompts.go
+++ b/pkg/configs/prompts.go
@@ -1,0 +1,70 @@
+package configs
+
+import (
+	"context"
+	"io/ioutil"
+	"os"
+	"strings"
+
+	"github.com/AlecAivazis/survey/v2"
+	"github.com/airplanedev/cli/pkg/api"
+	"github.com/airplanedev/cli/pkg/logger"
+	"github.com/airplanedev/cli/pkg/utils"
+	"github.com/pkg/errors"
+)
+
+// ReadValue reads a config value from prompt if allowed, else stdin
+func ReadValue(secret bool) (string, error) {
+	if utils.CanPrompt() {
+		return ReadValueFromPrompt("Config value:", secret)
+	}
+	// Read from stdin
+	logger.Log("Reading secret from stdin...")
+	data, err := ioutil.ReadAll(os.Stdin)
+	if err != nil {
+		return "", errors.Wrap(err, "reading from stdin")
+	}
+	return strings.TrimSpace(string(data)), nil
+}
+
+// ReadValueFromPrompt prompts user for config value
+func ReadValueFromPrompt(message string, secret bool) (string, error) {
+	var value string
+	var prompt survey.Prompt
+	if secret {
+		prompt = &survey.Password{Message: message}
+	} else {
+		prompt = &survey.Input{Message: message}
+	}
+	if err := survey.AskOne(
+		prompt,
+		&value,
+		survey.WithStdio(os.Stdin, os.Stderr, os.Stderr),
+	); err != nil {
+		return "", errors.Wrap(err, "prompting value")
+	}
+	return strings.TrimSpace(value), nil
+}
+
+// SetConfig writes config value to API and prints progress to user
+func SetConfig(ctx context.Context, client *api.Client, nt NameTag, value string, secret bool) error {
+	// Avoid printing back secrets
+	var valueStr string
+	if secret {
+		valueStr = "<secret value>"
+	} else {
+		valueStr = value
+	}
+	logger.Log("  Setting %s to %s...", logger.Blue(JoinName(nt)), logger.Green(valueStr))
+	req := api.SetConfigRequest{
+		Name:     nt.Name,
+		Tag:      nt.Tag,
+		Value:    value,
+		IsSecret: secret,
+	}
+	if err := client.SetConfig(ctx, req); err != nil {
+		return errors.Wrap(err, "set config")
+	}
+	logger.Log("  Done!")
+	return nil
+}


### PR DESCRIPTION
This refactors out and re-uses some of `configs set` code to ask the
user to enter in a config value if they try to deploy a task that is
missing configs.

This helps with creating new tasks from e.g. examples (or just when you
want to create a new config). You can run `deploy` and create the
missing configs then.

Resolves AIR-696
