### PR TITLE
Fix bug with `env` in `airplane.yml`

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -202,8 +202,8 @@ type ListTasksResponse struct {
 type TaskEnv map[string]EnvVarValue
 
 type EnvVarValue struct {
-	Value  string `json:"value" yaml:"value"`
-	Config string `json:"config" yaml:"config"`
+	Value  *string `json:"value" yaml:"value"`
+	Config *string `json:"config" yaml:"config"`
 }
 
 var _ yaml.Unmarshaler = &EnvVarValue{}
@@ -222,7 +222,7 @@ func (this *EnvVarValue) UnmarshalYAML(node *yaml.Node) error {
 	var value string
 	if err := node.Decode(&value); err == nil {
 		// Success!
-		this.Value = value
+		this.Value = &value
 		return nil
 	}
 

--- a/pkg/cmd/tasks/deploy/predeploy.go
+++ b/pkg/cmd/tasks/deploy/predeploy.go
@@ -18,8 +18,8 @@ import (
 func ensureConfigsExist(ctx context.Context, client *api.Client, def taskdir.Definition) error {
 	// Check if configs exist
 	for k, v := range def.Env {
-		if v.Config != "" {
-			if err := ensureConfigExists(ctx, client, k, v.Config); err != nil {
+		if v.Config != nil {
+			if err := ensureConfigExists(ctx, client, k, *v.Config); err != nil {
 				return err
 			}
 		}

--- a/pkg/cmd/tasks/initcmd/sample.go
+++ b/pkg/cmd/tasks/initcmd/sample.go
@@ -112,7 +112,7 @@ func pickSample(runtime runtimeKind) (string, error) {
 		},
 		runtimeKindGo: {
 			"Hello World": "github.com/airplanedev/examples/go/hello-world/airplane.yml",
-			"Run SQL":     "github.com/airplanedev/examples/go/sql/airplane.yml",
+			"Run SQL":     "github.com/airplanedev/examples/go/sql/airplane.yml@colin-config",
 		},
 		runtimeKindManual: {
 			"Hello World": "github.com/airplanedev/examples/manual/hello-world/airplane.yml",

--- a/pkg/cmd/tasks/initcmd/sample.go
+++ b/pkg/cmd/tasks/initcmd/sample.go
@@ -112,7 +112,7 @@ func pickSample(runtime runtimeKind) (string, error) {
 		},
 		runtimeKindGo: {
 			"Hello World": "github.com/airplanedev/examples/go/hello-world/airplane.yml",
-			"Run SQL":     "github.com/airplanedev/examples/go/sql/airplane.yml@colin-config",
+			"Run SQL":     "github.com/airplanedev/examples/go/sql/airplane.yml",
 		},
 		runtimeKindManual: {
 			"Hello World": "github.com/airplanedev/examples/manual/hello-world/airplane.yml",


### PR DESCRIPTION
Currently, any task definitions with an `env` section in their `airplane.yml` will error with an error about failing to connect configs.

I believe this broke when we changed the backend data model from `string` to `*string`, where we started looking for non-nil values rather than non-empty-string values.