### PR TITLE
Fix Go builder error with multi-file main packages (and add more debug info)

### DIFF
--- a/pkg/build/builder.go
+++ b/pkg/build/builder.go
@@ -219,22 +219,9 @@ func (b *Builder) Build(ctx context.Context, taskID, version string) (BuildOutpu
 		return BuildOutput{}, errors.Wrap(err, "copy output")
 	}
 
-	images, err := b.client.ImageList(ctx, types.ImageListOptions{})
-	if err != nil {
-		return BuildOutput{}, errors.Wrap(err, "image list")
-	}
-
-	for _, img := range images {
-		for _, t := range img.RepoTags {
-			if t == tag {
-				return BuildOutput{
-					Tag: t,
-				}, nil
-			}
-		}
-	}
-
-	return BuildOutput{}, fmt.Errorf("build: image with the tag %q was not found", tag)
+	return BuildOutput{
+		Tag: tag,
+	}, nil
 }
 
 // Push pushes the given image.

--- a/pkg/build/builder.go
+++ b/pkg/build/builder.go
@@ -164,7 +164,7 @@ func (b *Builder) Build(ctx context.Context, taskID, version string) (BuildOutpu
 	}
 	defer tree.Close()
 
-	buf, err := BuildDockerfile(DockerfileConfig{
+	dockerfile, err := BuildDockerfile(DockerfileConfig{
 		Builder: b.name,
 		Root:    b.root,
 		Args:    b.args,
@@ -172,8 +172,9 @@ func (b *Builder) Build(ctx context.Context, taskID, version string) (BuildOutpu
 	if err != nil {
 		return BuildOutput{}, errors.Wrap(err, "creating dockerfile")
 	}
+	logger.Debug(strings.TrimSpace(dockerfile))
 
-	if err := tree.Write("Dockerfile", strings.NewReader(buf)); err != nil {
+	if err := tree.Write("Dockerfile", strings.NewReader(dockerfile)); err != nil {
 		return BuildOutput{}, errors.Wrap(err, "writing dockerfile")
 	}
 

--- a/pkg/build/golang.go
+++ b/pkg/build/golang.go
@@ -29,7 +29,7 @@ RUN go mod download
 
 COPY . .
 
-RUN ["go", "build", "-o", "/bin/main", "/airplane/{{ .Entrypoint }}"]
+RUN ["go", "build", "-o", "/bin/main", "{{ .Entrypoint }}"]
 
 FROM {{ .Base }}
 
@@ -53,7 +53,7 @@ ENTRYPOINT ["/bin/main"]
 		HasGoSum   bool
 	}{
 		Base:       v.String(),
-		Entrypoint: entrypoint,
+		Entrypoint: filepath.Join("/airplane", entrypoint),
 		HasGoSum:   exist(gosum) == nil,
 	}); err != nil {
 		return "", err

--- a/pkg/build/local.go
+++ b/pkg/build/local.go
@@ -2,7 +2,6 @@ package build
 
 import (
 	"context"
-	"io"
 
 	"github.com/airplanedev/cli/pkg/api"
 	"github.com/airplanedev/cli/pkg/logger"
@@ -10,7 +9,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-func Local(ctx context.Context, client *api.Client, dir taskdir.TaskDirectory, def taskdir.Definition, taskID string, output io.Writer) error {
+func Local(ctx context.Context, client *api.Client, dir taskdir.TaskDirectory, def taskdir.Definition, taskID string) error {
 	registry, err := client.GetRegistryToken(ctx)
 	if err != nil {
 		return errors.Wrap(err, "getting registry token")
@@ -20,7 +19,6 @@ func Local(ctx context.Context, client *api.Client, dir taskdir.TaskDirectory, d
 		Root:    dir.DefinitionRootPath(),
 		Builder: def.Builder,
 		Args:    Args(def.BuilderConfig),
-		Writer:  output,
 		Auth: &RegistryAuth{
 			Token: registry.Token,
 			Repo:  registry.Repo,

--- a/pkg/cmd/tasks/deploy/deploy.go
+++ b/pkg/cmd/tasks/deploy/deploy.go
@@ -3,9 +3,6 @@ package deploy
 import (
 	"context"
 	"fmt"
-	"io"
-	"io/ioutil"
-	"os"
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/airplanedev/cli/pkg/api"
@@ -141,11 +138,7 @@ func run(ctx context.Context, cfg config) error {
 	if def.Builder != "" {
 		switch builder {
 		case build.BuilderKindLocal:
-			var output io.Writer = ioutil.Discard
-			if cfg.root.DebugMode {
-				output = os.Stderr
-			}
-			if err := build.Local(ctx, client, dir, def, taskID, output); err != nil {
+			if err := build.Local(ctx, client, dir, def, taskID); err != nil {
 				return err
 			}
 		case build.BuilderKindRemote:

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -14,17 +14,11 @@ var (
 // Log writes a log message to stderr, followed by a newline. Printf-style
 // formatting is applied to msg using args.
 func Log(msg string, args ...interface{}) {
-	LogInline(msg+"\n", args...)
-}
-
-// Log writes a log message to stderr. Printf-style
-// formatting is applied to msg using args.
-func LogInline(msg string, args ...interface{}) {
 	if len(args) == 0 {
 		// Use Fprint if no args - avoids treating msg like a format string
-		fmt.Fprint(os.Stderr, msg)
+		fmt.Fprint(os.Stderr, msg+"\n")
 	} else {
-		fmt.Fprintf(os.Stderr, msg, args...)
+		fmt.Fprintf(os.Stderr, msg+"\n", args...)
 	}
 }
 
@@ -32,18 +26,11 @@ func LogInline(msg string, args ...interface{}) {
 // is executing in debug mode. Printf-style formatting is applied to msg
 // using args.
 func Debug(msg string, args ...interface{}) {
-	DebugInline(msg+"\n", args...)
-}
-
-// Debug writes a log message to stderr if the CLI
-// is executing in debug mode. Printf-style formatting is applied to msg
-// using args.
-func DebugInline(msg string, args ...interface{}) {
 	if !EnableDebug {
 		return
 	}
 
-	msgf := msg
+	msgf := msg + "\n"
 	if len(args) > 0 {
 		msgf = fmt.Sprintf(msg, args...)
 	}

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -3,6 +3,7 @@ package logger
 import (
 	"fmt"
 	"os"
+	"strings"
 )
 
 var (
@@ -41,10 +42,14 @@ func DebugInline(msg string, args ...interface{}) {
 	if !EnableDebug {
 		return
 	}
-	debugPrefix := "[" + Blue("debug") + "] "
-	if len(args) == 0 {
-		fmt.Fprint(os.Stderr, debugPrefix+msg)
-	} else {
-		fmt.Fprintf(os.Stderr, debugPrefix+msg, args...)
+
+	msgf := msg
+	if len(args) > 0 {
+		msgf = fmt.Sprintf(msg, args...)
 	}
+
+	debugPrefix := "[" + Blue("debug") + "] "
+	msgf = debugPrefix + strings.Join(strings.Split(msgf, "\n"), "\n"+debugPrefix)
+
+	fmt.Fprint(os.Stderr, msgf)
 }

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -13,11 +13,17 @@ var (
 // Log writes a log message to stderr, followed by a newline. Printf-style
 // formatting is applied to msg using args.
 func Log(msg string, args ...interface{}) {
+	LogInline(msg+"\n", args...)
+}
+
+// Log writes a log message to stderr. Printf-style
+// formatting is applied to msg using args.
+func LogInline(msg string, args ...interface{}) {
 	if len(args) == 0 {
 		// Use Fprint if no args - avoids treating msg like a format string
-		fmt.Fprint(os.Stderr, msg+"\n")
+		fmt.Fprint(os.Stderr, msg)
 	} else {
-		fmt.Fprintf(os.Stderr, msg+"\n", args...)
+		fmt.Fprintf(os.Stderr, msg, args...)
 	}
 }
 
@@ -25,13 +31,20 @@ func Log(msg string, args ...interface{}) {
 // is executing in debug mode. Printf-style formatting is applied to msg
 // using args.
 func Debug(msg string, args ...interface{}) {
+	DebugInline(msg+"\n", args...)
+}
+
+// Debug writes a log message to stderr if the CLI
+// is executing in debug mode. Printf-style formatting is applied to msg
+// using args.
+func DebugInline(msg string, args ...interface{}) {
 	if !EnableDebug {
 		return
 	}
 	debugPrefix := "[" + Blue("debug") + "] "
 	if len(args) == 0 {
-		fmt.Fprint(os.Stderr, debugPrefix+msg+"\n")
+		fmt.Fprint(os.Stderr, debugPrefix+msg)
 	} else {
-		fmt.Fprintf(os.Stderr, debugPrefix+msg+"\n", args...)
+		fmt.Fprintf(os.Stderr, debugPrefix+msg, args...)
 	}
 }

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -30,7 +30,7 @@ func Debug(msg string, args ...interface{}) {
 		return
 	}
 
-	msgf := msg + "\n"
+	msgf := msg
 	if len(args) > 0 {
 		msgf = fmt.Sprintf(msg, args...)
 	}
@@ -38,5 +38,5 @@ func Debug(msg string, args ...interface{}) {
 	debugPrefix := "[" + Blue("debug") + "] "
 	msgf = debugPrefix + strings.Join(strings.Split(msgf, "\n"), "\n"+debugPrefix)
 
-	fmt.Fprint(os.Stderr, msgf)
+	fmt.Fprint(os.Stderr, msgf+"\n")
 }


### PR DESCRIPTION
I ran into an issue where the Go builder was failing to compile our Run SQL example. After doing some digging, I found a fix -- the Go entrypoint should be the main package unless there's only a single file in the main pkg.

While debugging, I ended up making some cleanups that I've included here:

## Docker Logs

Previously, we only showed these logs if you ran with the `--debug` flag. We now parse the JSON-based Docker events from both building and pushing and render them to stderr.

## Failing on docker errors

Now that we parse Docker logs, we can detect if the build or push failed since this information is only conveyed in the logs (rather than via an `error` from the Docker client). For example, previously if a builder failed at any point in executing a Dockerfile, you got a confusing error -- that the tag could not be found.

![image](https://user-images.githubusercontent.com/2907397/115082359-cd06e000-9ed3-11eb-9fc6-fa5e37a3ef44.png)


## Print Dockerfile when `--debug`

We now log the generated Dockerfile when run with `--debug`.

## Multi-line debug prefix

Since Dockerfiles span multiple lines, the `[debug]` prefix was only rendering on the first line. To make this look nice, I've updated the `logger.Debug` function to split the debug message by newlines in order to insert the `[debug]` prefix on every line.