### PR TITLE
Filter out symlinks from uploads

### DIFF
--- a/pkg/build/remote.go
+++ b/pkg/build/remote.go
@@ -77,7 +77,6 @@ func archiveTaskDir(dir taskdir.TaskDirectory, archivePath string) error {
 	if err != nil {
 		return err
 	}
-	arch.Tar.ContinueOnError = true
 
 	if err := arch.Archive(sources, archivePath); err != nil {
 		return errors.Wrap(err, "building archive")


### PR DESCRIPTION
This should resolve an issue where a dependency had a symlink to a file (`foobar/.bin/foobar`) that did not exist.