### PR TITLE
Attach `X-Airplane-Client` and `X-Airplane-Version` headers

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -9,7 +9,7 @@ builds:
     env:
       - CGO_ENABLED=0
     ldflags:
-      - -s -w -X github.com/airplanedev/cli/pkg/cmd/version.version={{.Version}} -X github.com/airplanedev/cli/pkg/cmd/version.compileDate={{.Date}}
+      - -s -w -X github.com/airplanedev/cli/pkg/version.version={{.Version}} -X github.com/airplanedev/cli/pkg/version.date={{.Date}}
     goos:
       - linux
       - windows

--- a/pkg/api/client.go
+++ b/pkg/api/client.go
@@ -13,6 +13,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/airplanedev/cli/pkg/version"
+
 	"github.com/pkg/errors"
 )
 
@@ -274,6 +276,9 @@ func (c Client) do(ctx context.Context, method, path string, payload, reply inte
 	}
 
 	req.Header.Set("X-Airplane-Token", token)
+	req.Header.Set("X-Airplane-Client", "cli")
+	req.Header.Set("X-Airplane-Version", version.Get())
+
 	resp, err := http.DefaultClient.Do(req)
 
 	if resp != nil {

--- a/pkg/cmd/version/version.go
+++ b/pkg/cmd/version/version.go
@@ -6,13 +6,8 @@ import (
 
 	"github.com/airplanedev/cli/pkg/cli"
 	"github.com/airplanedev/cli/pkg/logger"
+	"github.com/airplanedev/cli/pkg/version"
 	"github.com/spf13/cobra"
-)
-
-// Set by Go Releaser.
-var (
-	version     string = "<unknown>"
-	compileDate string = "<unknown>"
 )
 
 func New(c *cli.Config) *cobra.Command {
@@ -29,7 +24,7 @@ func New(c *cli.Config) *cobra.Command {
 }
 
 func Version() string {
-	return fmt.Sprintf("Version: %s (%s)", version, compileDate)
+	return fmt.Sprintf("Version: %s (%s)", version.Get(), version.Date())
 }
 
 func run(ctx context.Context) error {

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,0 +1,15 @@
+package version
+
+// Set by Go Releaser.
+var (
+	version string = "<unknown>"
+	date    string = "<unknown>"
+)
+
+func Get() string {
+	return version
+}
+
+func Date() string {
+	return date
+}


### PR DESCRIPTION
We will use these headers to debug errors from the CLI.