### PR TITLE
Add support to `auth info` for `-o` flag

### DIFF
--- a/pkg/cmd/auth/info/info.go
+++ b/pkg/cmd/auth/info/info.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/airplanedev/cli/pkg/cli"
 	"github.com/airplanedev/cli/pkg/logger"
+	"github.com/airplanedev/cli/pkg/print"
 	"github.com/spf13/cobra"
 )
 
@@ -27,14 +28,21 @@ func run(ctx context.Context, c *cli.Config) error {
 		return err
 	}
 
-	var userStr string
-	if res.User == nil {
-		userStr = logger.Gray("<no user>")
-	} else {
-		userStr = res.User.Email
+	switch f := print.DefaultFormatter.(type) {
+	case *print.JSON:
+		f.Encode(res)
+	case print.YAML:
+		f.Encode(res)
+	default:
+		var userStr string
+		if res.User == nil {
+			userStr = logger.Gray("<no user>")
+		} else {
+			userStr = res.User.Email
+		}
+		logger.Log("  Signed in as %s", logger.Blue(userStr))
+		logger.Log("  Using team %s (ID: %s)", logger.Blue(res.Team.Name), res.Team.ID)
 	}
-	logger.Log("  Signed in as %s", logger.Blue(userStr))
-	logger.Log("  Using team %s (ID: %s)", logger.Blue(res.Team.Name), res.Team.ID)
 
 	return nil
 }

--- a/pkg/cmd/auth/info/info.go
+++ b/pkg/cmd/auth/info/info.go
@@ -28,12 +28,7 @@ func run(ctx context.Context, c *cli.Config) error {
 		return err
 	}
 
-	switch f := print.DefaultFormatter.(type) {
-	case *print.JSON:
-		f.Encode(res)
-	case print.YAML:
-		f.Encode(res)
-	default:
+	print.Print(res, func() {
 		var userStr string
 		if res.User == nil {
 			userStr = logger.Gray("<no user>")
@@ -42,7 +37,7 @@ func run(ctx context.Context, c *cli.Config) error {
 		}
 		logger.Log("  Signed in as %s", logger.Blue(userStr))
 		logger.Log("  Using team %s (ID: %s)", logger.Blue(res.Team.Name), res.Team.ID)
-	}
+	})
 
 	return nil
 }

--- a/pkg/print/json.go
+++ b/pkg/print/json.go
@@ -19,6 +19,11 @@ func NewJSONFormatter() *JSON {
 	}
 }
 
+// Encode allows external callers to use the same encoder
+func (j *JSON) Encode(obj interface{}) {
+	j.enc.Encode(obj)
+}
+
 // APIKeys implementation.
 func (j *JSON) apiKeys(apiKeys []api.APIKey) {
 	j.enc.Encode(apiKeys)

--- a/pkg/print/print.go
+++ b/pkg/print/print.go
@@ -57,3 +57,17 @@ func Outputs(outputs api.Outputs) {
 func Config(config api.Config) {
 	DefaultFormatter.config(config)
 }
+
+// Print outputs obj based on DefaultFormatter
+// If JSON or YAML, uses that formatter to encode obj
+// Otherwise, calls defaultPrintFunc to render the obj
+func Print(obj interface{}, defaultPrintFunc func()) {
+	switch f := DefaultFormatter.(type) {
+	case *JSON:
+		f.Encode(obj)
+	case YAML:
+		f.Encode(obj)
+	default:
+		defaultPrintFunc()
+	}
+}

--- a/pkg/print/table.go
+++ b/pkg/print/table.go
@@ -95,16 +95,18 @@ func (t Table) task(task api.Task) {
 		builderStr = "manual"
 	}
 
-	fmt.Fprintln(os.Stdout, "Name:    ", task.Name)
-	fmt.Fprintln(os.Stdout, "Slug:    ", task.Slug)
-	fmt.Fprintln(os.Stdout, "Builder: ", builderStr)
+	fmt.Fprintln(os.Stdout, "Name:       ", task.Name)
+	fmt.Fprintln(os.Stdout, "Slug:       ", task.Slug)
+	fmt.Fprintln(os.Stdout, "Description:", task.Description)
+	fmt.Fprintln(os.Stdout, "Builder:    ", builderStr)
 	fmt.Fprintln(os.Stdout, "")
 
 	if len(task.Parameters) > 0 {
+		fmt.Fprintln(os.Stdout, "Task Parameters:")
+		fmt.Fprintln(os.Stdout, "")
 		tw := tablewriter.NewWriter(os.Stdout)
 		tw.SetBorder(false)
 		tw.SetHeader([]string{"name", "slug", "description", "type", "required", "default"})
-		tw.SetCaption(true, "Task Parameters")
 
 		for _, p := range task.Parameters {
 			requiredStr := "yes"

--- a/pkg/print/yaml.go
+++ b/pkg/print/yaml.go
@@ -12,6 +12,11 @@ import (
 // Its zero-value is ready for use.
 type YAML struct{}
 
+// Encode allows external callers to use the same encoder
+func (YAML) Encode(obj interface{}) {
+	yaml.NewEncoder(os.Stdout).Encode(obj)
+}
+
 // APIKeys implementation.
 func (YAML) apiKeys(apiKeys []api.APIKey) {
 	yaml.NewEncoder(os.Stdout).Encode(apiKeys)


### PR DESCRIPTION
This enables `airplane auth info -o json | jq .team.id`:

```
$ airplane auth info -o json
{"user":{"id":"prof_01EQV9VY8D2NEK6X2BFRXC2BM8","email":"josh@airplane.dev"},"team":{"id":"1jq9NDeTcTmyqqXAjEsk7V0wXaV","name":"Airplane"}}

$ airplane auth info -o json | jq -r .team.id
1jq9NDeTcTmyqqXAjEsk7V0wXaV
```
