### PR TITLE
Add buildCommand and buildDir to Node builderConfig

### DIFF
--- a/pkg/build/node.go
+++ b/pkg/build/node.go
@@ -75,7 +75,7 @@ func node(root string, args Args) (string, error) {
 FROM {{ .Base }}
 
 WORKDIR {{ .Workdir }}
-COPY . /airplane
+COPY . {{ .Workdir }}
 {{ range .Commands }}
 RUN {{ . }}
 {{ end }}

--- a/pkg/build/node.go
+++ b/pkg/build/node.go
@@ -2,9 +2,12 @@ package build
 
 import (
 	"fmt"
+	"path"
 	"path/filepath"
 	"strings"
 	"text/template"
+
+	"github.com/pkg/errors"
 )
 
 // Node creates a dockerfile for Node (typescript/javascript).
@@ -19,6 +22,12 @@ func node(root string, args Args) (string, error) {
 	var pkglock = filepath.Join(root, "package-lock.json")
 	var version = args["nodeVersion"]
 	var lang = args["language"]
+	// `workdir` is fixed usually - `buildWorkdir` is a subdirectory of `workdir` if there's
+	// `buildCommand` and is ultimately where `entrypoint` is run from.
+	var buildCommand = args["buildCommand"]
+	var buildDir = args["buildDir"]
+	var workdir = "/airplane"
+	var buildWorkdir = "/airplane"
 	var cmds []string
 
 	// Make sure that entrypoint and `package.json` exist.
@@ -38,27 +47,37 @@ func node(root string, args Args) (string, error) {
 	case "typescript":
 		cmds = append(cmds, `npm install -g typescript@4.1`)
 		cmds = append(cmds, `[-f tsconfig.json] || echo '{"include": ["*", "**/*"], "exclude": ["node_modules"]}' >tsconfig.json`)
-		cmds = append(cmds, `rm -rf .airplane-build/ && tsc --outDir .airplane-build --rootDir .`)
-		entrypoint = "/airplane/.airplane-build/" + strings.TrimSuffix(entrypoint, ".ts") + ".js"
-
+		cmd := `rm -rf .airplane-build/ && tsc --outDir .airplane-build --rootDir .`
+		if buildCommand != "" {
+			cmd += fmt.Sprintf(" && %s", buildCommand)
+		}
+		cmds = append(cmds, cmd)
+		buildWorkdir = path.Join(workdir, ".airplane-build")
+		// If entrypoint ends in .ts, replace it with .js
+		entrypoint = strings.TrimSuffix(entrypoint, ".ts") + ".js"
 	case "javascript":
-		entrypoint = "/airplane/" + entrypoint
-
+		if buildCommand != "" {
+			cmds = append(cmds, buildCommand)
+		}
+		if buildDir != "" {
+			buildWorkdir = path.Join(workdir, buildDir)
+		}
 	default:
-		return "", fmt.Errorf("build: unknown language %q, it must be javascript or tyescript", lang)
-
+		return "", errors.Errorf("build: unknown language %q, expected \"javascript\" or \"typescript\"", lang)
 	}
+	entrypoint = path.Join(buildWorkdir, entrypoint)
 
 	// Dockerfile template.
 	t, err := template.New("node").Parse(`
 FROM {{ .Base }}
 
-WORKDIR /airplane
+WORKDIR {{ .Workdir }}
 COPY . /airplane
 {{ range .Commands }}
 RUN {{ . }}
 {{ end }}
 
+WORKDIR {{ .BuildWorkdir }}
 ENTRYPOINT ["node", "{{ .Main }}"]
 `)
 	if err != nil {
@@ -80,13 +99,17 @@ ENTRYPOINT ["node", "{{ .Main }}"]
 
 	var buf strings.Builder
 	if err := t.Execute(&buf, struct {
-		Base     string
-		Commands []string
-		Main     string
+		Base         string
+		Workdir      string
+		BuildWorkdir string
+		Commands     []string
+		Main         string
 	}{
-		Base:     base,
-		Commands: cmds,
-		Main:     entrypoint,
+		Base:         base,
+		Workdir:      workdir,
+		BuildWorkdir: buildWorkdir,
+		Commands:     cmds,
+		Main:         entrypoint,
 	}); err != nil {
 		return "", err
 	}

--- a/pkg/build/node.go
+++ b/pkg/build/node.go
@@ -45,14 +45,17 @@ func node(root string, args Args) (string, error) {
 	// Language specific.
 	switch lang {
 	case "typescript":
+		if buildDir == "" {
+			buildDir = ".airplane-build"
+		}
 		cmds = append(cmds, `npm install -g typescript@4.1`)
 		cmds = append(cmds, `[-f tsconfig.json] || echo '{"include": ["*", "**/*"], "exclude": ["node_modules"]}' >tsconfig.json`)
-		cmd := `rm -rf .airplane-build/ && tsc --outDir .airplane-build --rootDir .`
+		cmds = append(cmds, fmt.Sprintf(`rm -rf %s && tsc --outDir %s --rootDir .`, buildDir, buildDir))
 		if buildCommand != "" {
-			cmd += fmt.Sprintf(" && %s", buildCommand)
+			// It's not totally expected, but if you do set buildCommand we'll run it after tsc
+			cmds = append(cmds, buildCommand)
 		}
-		cmds = append(cmds, cmd)
-		buildWorkdir = path.Join(workdir, ".airplane-build")
+		buildWorkdir = path.Join(workdir, buildDir)
 		// If entrypoint ends in .ts, replace it with .js
 		entrypoint = strings.TrimSuffix(entrypoint, ".ts") + ".js"
 	case "javascript":


### PR DESCRIPTION
- `buildCommand` is something like `npm run build` that you want run
  after dependencies are installed
- `buildDir` is the output directory of build - this is where we'll cd
  into and wher we'll find `entrypoint`

So if your build outputs to `.airplane/main.js`, you'll want
`buildDir=.airplane` and `entrypoint=main.js`.
