### PR TITLE
Add support for buildEnv and NPM auth in local builder

### DIFF
--- a/pkg/build/local.go
+++ b/pkg/build/local.go
@@ -2,7 +2,6 @@ package build
 
 import (
 	"context"
-	"strings"
 
 	"github.com/airplanedev/cli/pkg/api"
 	"github.com/airplanedev/cli/pkg/logger"
@@ -19,7 +18,7 @@ func Local(ctx context.Context, client *api.Client, dir taskdir.TaskDirectory, d
 	buildEnv := make(map[string]string)
 	// TODO: currently, we just read non-config values from env. Should ask API for full BuildEnv instead.
 	for k, v := range def.Env {
-		if strings.HasPrefix(k, "BUILD_") && v.Value != nil {
+		if v.Value != nil {
 			buildEnv[k] = *v.Value
 		}
 	}

--- a/pkg/build/node.go
+++ b/pkg/build/node.go
@@ -49,7 +49,7 @@ func node(root string, args Args) (string, error) {
 			buildDir = ".airplane-build"
 		}
 		cmds = append(cmds, `npm install -g typescript@4.1`)
-		cmds = append(cmds, `[-f tsconfig.json] || echo '{"include": ["*", "**/*"], "exclude": ["node_modules"]}' >tsconfig.json`)
+		cmds = append(cmds, `[ -f tsconfig.json ] || echo '{"include": ["*", "**/*"], "exclude": ["node_modules"]}' >tsconfig.json`)
 		cmds = append(cmds, fmt.Sprintf(`rm -rf %s && tsc --outDir %s --rootDir .`, buildDir, buildDir))
 		if buildCommand != "" {
 			// It's not totally expected, but if you do set buildCommand we'll run it after tsc

--- a/pkg/build/node.go
+++ b/pkg/build/node.go
@@ -75,6 +75,13 @@ func node(root string, args Args) (string, error) {
 FROM {{ .Base }}
 
 WORKDIR {{ .Workdir }}
+
+# Support setting BUILD_NPM_RC or BUILD_NPM_TOKEN to configure private registry auth
+ARG BUILD_NPM_RC
+ARG BUILD_NPM_TOKEN
+RUN [ -z "${BUILD_NPM_RC}" ] || "${BUILD_NPM_RC}" > .npmrc
+RUN [ -z "${BUILD_NPM_TOKEN}" ] || echo "//registry.npmjs.org/:_authToken=${BUILD_NPM_TOKEN}" > .npmrc
+
 COPY . {{ .Workdir }}
 {{ range .Commands }}
 RUN {{ . }}

--- a/pkg/build/node.go
+++ b/pkg/build/node.go
@@ -79,7 +79,7 @@ WORKDIR {{ .Workdir }}
 # Support setting BUILD_NPM_RC or BUILD_NPM_TOKEN to configure private registry auth
 ARG BUILD_NPM_RC
 ARG BUILD_NPM_TOKEN
-RUN [ -z "${BUILD_NPM_RC}" ] || "${BUILD_NPM_RC}" > .npmrc
+RUN [ -z "${BUILD_NPM_RC}" ] || echo "${BUILD_NPM_RC}" > .npmrc
 RUN [ -z "${BUILD_NPM_TOKEN}" ] || echo "//registry.npmjs.org/:_authToken=${BUILD_NPM_TOKEN}" > .npmrc
 
 COPY . {{ .Workdir }}


### PR DESCRIPTION
This is a first iteration that adds support for hardcoded env values (i.e. not config values) - setting BUILD_NPM_AUTH or BUILD_NPM_TOKEN will result in a `.npmrc` file created.

A future change will add support for fetching a full buildEnv from API instead.

You can test this with a task using `@airplane/npm-private-pkg` and env like:

```
env:
  BUILD_NPM_TOKEN: <get this from npm website>
```