### PR TITLE
Add full support for local build env vars

### DIFF
--- a/pkg/api/client.go
+++ b/pkg/api/client.go
@@ -186,12 +186,8 @@ func (c Client) GetTask(ctx context.Context, slug string) (res Task, err error) 
 }
 
 // GetConfig returns a config by name and tag.
-func (c Client) GetConfig(ctx context.Context, name, tag string) (res GetConfigResponse, err error) {
-	q := url.Values{
-		"name": []string{name},
-		"tag":  []string{tag},
-	}
-	err = c.do(ctx, "GET", "/configs/get?"+q.Encode(), nil, &res)
+func (c Client) GetConfig(ctx context.Context, req GetConfigRequest) (res GetConfigResponse, err error) {
+	err = c.do(ctx, "POST", "/configs/get", req, &res)
 	return
 }
 

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -323,6 +323,13 @@ type ListRunsResponse struct {
 	Runs []Run `json:"runs"`
 }
 
+// GetConfigRequest represents a get config request
+type GetConfigRequest struct {
+	Name       string `json:"name"`
+	Tag        string `json:"tag"`
+	ShowSecret bool   `json:"showSecret"`
+}
+
 // SetConfigRequest represents a set config request.
 type SetConfigRequest struct {
 	Name     string `json:"name"`

--- a/pkg/build/local.go
+++ b/pkg/build/local.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/airplanedev/cli/pkg/api"
+	"github.com/airplanedev/cli/pkg/configs"
 	"github.com/airplanedev/cli/pkg/logger"
 	"github.com/airplanedev/cli/pkg/taskdir"
 	"github.com/pkg/errors"
@@ -15,12 +16,9 @@ func Local(ctx context.Context, client *api.Client, dir taskdir.TaskDirectory, d
 		return errors.Wrap(err, "getting registry token")
 	}
 
-	buildEnv := make(map[string]string)
-	// TODO: currently, we just read non-config values from env. Should ask API for full BuildEnv instead.
-	for k, v := range def.Env {
-		if v.Value != nil {
-			buildEnv[k] = *v.Value
-		}
+	buildEnv, err := getBuildEnv(ctx, client, def)
+	if err != nil {
+		return err
 	}
 
 	b, err := New(LocalConfig{
@@ -49,4 +47,30 @@ func Local(ctx context.Context, client *api.Client, dir taskdir.TaskDirectory, d
 	}
 
 	return nil
+}
+
+// Retreives a build env from def - looks for env vars starting with BUILD_ and either uses the
+// string literal or looks up the config value.
+func getBuildEnv(ctx context.Context, client *api.Client, def taskdir.Definition) (map[string]string, error) {
+	buildEnv := make(map[string]string)
+	for k, v := range def.Env {
+		if v.Value != nil {
+			buildEnv[k] = *v.Value
+		} else if v.Config != nil {
+			nt, err := configs.ParseName(*v.Config)
+			if err != nil {
+				return nil, err
+			}
+			res, err := client.GetConfig(ctx, api.GetConfigRequest{
+				Name:       nt.Name,
+				Tag:        nt.Tag,
+				ShowSecret: true,
+			})
+			if err != nil {
+				return nil, err
+			}
+			buildEnv[k] = res.Config.Value
+		}
+	}
+	return buildEnv, nil
 }

--- a/pkg/cmd/configs/get/get.go
+++ b/pkg/cmd/configs/get/get.go
@@ -3,6 +3,7 @@ package get
 import (
 	"context"
 
+	"github.com/airplanedev/cli/pkg/api"
 	"github.com/airplanedev/cli/pkg/cli"
 	"github.com/airplanedev/cli/pkg/configs"
 	"github.com/airplanedev/cli/pkg/print"
@@ -33,7 +34,11 @@ func run(ctx context.Context, c *cli.Config, name string) error {
 	if err == configs.ErrInvalidConfigName {
 		return errors.Errorf("invalid config name: %s - expected my_config or my_config:tag", name)
 	}
-	resp, err := client.GetConfig(ctx, nt.Name, nt.Tag)
+	resp, err := client.GetConfig(ctx, api.GetConfigRequest{
+		Name:       nt.Name,
+		Tag:        nt.Tag,
+		ShowSecret: false,
+	})
 	if err != nil {
 		return errors.Wrap(err, "get config")
 	}

--- a/pkg/cmd/tasks/deploy/predeploy.go
+++ b/pkg/cmd/tasks/deploy/predeploy.go
@@ -32,7 +32,10 @@ func ensureConfigExists(ctx context.Context, client *api.Client, envName, config
 	if err != nil {
 		return err
 	}
-	_, err = client.GetConfig(ctx, cn.Name, cn.Tag)
+	_, err = client.GetConfig(ctx, api.GetConfigRequest{
+		Name: cn.Name,
+		Tag:  cn.Tag,
+	})
 	if err == nil {
 		return nil
 	}


### PR DESCRIPTION
This expands on the previous change and will query for config values as well, via API.

Depends on changes in https://github.com/airplanedev/airport/pull/393