### PR TITLE
Fix `init --from` bugs

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -137,7 +137,7 @@ type Parameter struct {
 	Type        Type        `json:"type" yaml:"type"`
 	Desc        string      `json:"desc" yaml:"desc,omitempty"`
 	Component   Component   `json:"component" yaml:"component,omitempty"`
-	Default     Value       `json:"default" yaml:"default"`
+	Default     Value       `json:"default" yaml:"default,omitempty"`
 	Constraints Constraints `json:"constraints" yaml:"constraints,omitempty"`
 }
 

--- a/pkg/cmd/tasks/initcmd/task.go
+++ b/pkg/cmd/tasks/initcmd/task.go
@@ -31,7 +31,7 @@ func initFromTask(ctx context.Context, cfg config) error {
 	if file == "" {
 		file = "airplane.yml"
 	}
-	dir, err := taskdir.Open(file)
+	dir, err := taskdir.New(file)
 	if err != nil {
 		return errors.Wrap(err, "opening task directory")
 	}
@@ -42,11 +42,10 @@ func initFromTask(ctx context.Context, cfg config) error {
 		return errors.Wrap(err, "getting unique slug")
 	}
 
-	if err := dir.WriteDefinition(taskdir.Definition{
+	def := taskdir.Definition{
 		Slug:           r.Slug,
 		Name:           task.Name,
 		Description:    task.Description,
-		Image:          task.Image,
 		Command:        task.Command,
 		Arguments:      task.Arguments,
 		Parameters:     task.Parameters,
@@ -57,7 +56,12 @@ func initFromTask(ctx context.Context, cfg config) error {
 		BuilderConfig:  task.BuilderConfig,
 		Repo:           task.Repo,
 		Timeout:        task.Timeout,
-	}); err != nil {
+	}
+	// Only show the image field if this is a manual builder
+	if task.Builder == "manual" {
+		def.Image = task.Image
+	}
+	if err := dir.WriteDefinition(def); err != nil {
 		return errors.Wrap(err, "writing task definition")
 	}
 


### PR DESCRIPTION
Fixes issue where `airplane.yml` was not found and so `taskdir.Open`
erorred (now uses `taskdir.New` instead).

Fixes issue where null `default` values in parameters were showing up -
uses `omitempty` now to leave those out.

Fixes issue where `image` field was set for non-manual builders - since
we probably still want to show that in the API, this at least refrains
from writing that to the task definition if the builder is not manual.
