### PR TITLE
Perform remote builds by default

### DIFF
--- a/pkg/cmd/tasks/deploy/deploy.go
+++ b/pkg/cmd/tasks/deploy/deploy.go
@@ -41,10 +41,7 @@ func New(c *cli.Config) *cobra.Command {
 	}
 
 	cmd.Flags().StringVarP(&cfg.file, "file", "f", "", "Path to a task definition file.")
-	cmd.Flags().StringVar(&cfg.builder, "builder", string(build.BuilderKindLocal), "Where to build the task's Docker image. Accepts: [local, remote]")
-
-	// TODO: make "remote" the default once and un-hide this flag once it is fully implemented.
-	cli.Must(cmd.Flags().MarkHidden("builder"))
+	cmd.Flags().StringVar(&cfg.builder, "builder", string(build.BuilderKindRemote), "Where to build the task's Docker image. Accepts: [local, remote]")
 
 	cli.Must(cmd.MarkFlagRequired("file"))
 


### PR DESCRIPTION
We've made a number of improvements to our hosted builder, so we're now ready for that to replace the local builder as the default.

This PR won't merge until the relevant backend changes are live.