### PR TITLE
Improve remote builder logs

### DIFF
--- a/pkg/build/node.go
+++ b/pkg/build/node.go
@@ -49,7 +49,7 @@ func node(root string, args Args) (string, error) {
 			buildDir = ".airplane-build"
 		}
 		cmds = append(cmds, `npm install -g typescript@4.1`)
-		cmds = append(cmds, `[-f tsconfig.json] || echo '{"include": ["*", "**/*"], "exclude": ["node_modules"]}' >tsconfig.json`)
+		cmds = append(cmds, `[ -f tsconfig.json ] || echo '{"include": ["*", "**/*"], "exclude": ["node_modules"]}' >tsconfig.json`)
 		cmds = append(cmds, fmt.Sprintf(`rm -rf %s && tsc --outDir %s --rootDir .`, buildDir, buildDir))
 		if buildCommand != "" {
 			// It's not totally expected, but if you do set buildCommand we'll run it after tsc

--- a/pkg/build/remote.go
+++ b/pkg/build/remote.go
@@ -45,6 +45,7 @@ func Remote(ctx context.Context, dir taskdir.TaskDirectory, client *api.Client, 
 	if err != nil {
 		return errors.Wrap(err, "creating build")
 	}
+	logger.Debug("Created build with id=%s", build.Build.ID)
 
 	if err := waitForBuild(ctx, client, build.Build.ID); err != nil {
 		return err
@@ -201,7 +202,7 @@ func uploadArchive(ctx context.Context, client *api.Client, archivePath string) 
 	}
 	sizeBytes := int(info.Size())
 
-	logger.Debug("Uploading %s archive...", humanize.Bytes(uint64(sizeBytes)))
+	buildLog(logger.Gray("Uploading %s build archive", humanize.Bytes(uint64(sizeBytes))))
 
 	upload, err := client.CreateBuildUpload(ctx, api.CreateBuildUploadRequest{
 		SizeBytes: sizeBytes,
@@ -222,12 +223,15 @@ func uploadArchive(ctx context.Context, client *api.Client, archivePath string) 
 	}
 	defer resp.Body.Close()
 
-	logger.Debug("Upload complete: %s", upload.Upload.URL)
+	buildLog(logger.Gray("Upload complete"))
+	logger.Debug("Upload available: %s", upload.Upload.URL)
 
 	return upload.Upload.ID, nil
 }
 
 func waitForBuild(ctx context.Context, client *api.Client, buildID string) error {
+	buildLog(logger.Gray("Waiting for build to be assigned"))
+
 	t := time.NewTicker(time.Second)
 
 	var since time.Time
@@ -245,7 +249,6 @@ func waitForBuild(ctx context.Context, client *api.Client, buildID string) error
 				since = r.Logs[len(r.Logs)-1].Timestamp
 			}
 
-			buildPrefix := "[" + logger.Yellow("build") + "] "
 			newLogs := api.DedupeLogs(logs, r.Logs)
 			for _, l := range newLogs {
 				text := l.Text
@@ -253,7 +256,7 @@ func waitForBuild(ctx context.Context, client *api.Client, buildID string) error
 					text = logger.Gray(strings.TrimPrefix(text, "[builder] "))
 				}
 
-				logger.Log(buildPrefix + text)
+				buildLog(text)
 			}
 			logs = append(logs, newLogs...)
 
@@ -263,8 +266,21 @@ func waitForBuild(ctx context.Context, client *api.Client, buildID string) error
 			}
 
 			if b.Build.Status.Stopped() {
+				switch b.Build.Status {
+				case api.BuildCancelled:
+					logger.Log("\nBuild " + logger.Bold(logger.Yellow("cancelled")))
+				case api.BuildFailed:
+					logger.Log("\nBuild " + logger.Bold(logger.Red("failed")))
+				case api.BuildSucceeded:
+					logger.Log("\nBuild " + logger.Bold(logger.Green("succeeded")))
+				}
+
 				return nil
 			}
 		}
 	}
+}
+
+func buildLog(msg string, args ...interface{}) {
+	logger.Log("["+logger.Yellow("build")+"] "+msg, args...)
 }

--- a/pkg/build/remote.go
+++ b/pkg/build/remote.go
@@ -223,8 +223,7 @@ func uploadArchive(ctx context.Context, client *api.Client, archivePath string) 
 	}
 	defer resp.Body.Close()
 
-	buildLog(logger.Gray("Upload complete."))
-	logger.Debug("Upload available: %s", upload.Upload.URL)
+	logger.Debug("Upload complete: %s", upload.Upload.URL)
 
 	return upload.Upload.ID, nil
 }

--- a/pkg/build/remote.go
+++ b/pkg/build/remote.go
@@ -202,7 +202,7 @@ func uploadArchive(ctx context.Context, client *api.Client, archivePath string) 
 	}
 	sizeBytes := int(info.Size())
 
-	buildLog(logger.Gray("Uploading %s build archive", humanize.Bytes(uint64(sizeBytes))))
+	buildLog(logger.Gray("Uploading %s build archive...", humanize.Bytes(uint64(sizeBytes))))
 
 	upload, err := client.CreateBuildUpload(ctx, api.CreateBuildUploadRequest{
 		SizeBytes: sizeBytes,
@@ -223,14 +223,14 @@ func uploadArchive(ctx context.Context, client *api.Client, archivePath string) 
 	}
 	defer resp.Body.Close()
 
-	buildLog(logger.Gray("Upload complete"))
+	buildLog(logger.Gray("Upload complete."))
 	logger.Debug("Upload available: %s", upload.Upload.URL)
 
 	return upload.Upload.ID, nil
 }
 
 func waitForBuild(ctx context.Context, client *api.Client, buildID string) error {
-	buildLog(logger.Gray("Waiting for build to be assigned"))
+	buildLog(logger.Gray("Waiting for build to be assigned..."))
 
 	t := time.NewTicker(time.Second)
 

--- a/pkg/cmd/tasks/deploy/deploy.go
+++ b/pkg/cmd/tasks/deploy/deploy.go
@@ -41,10 +41,7 @@ func New(c *cli.Config) *cobra.Command {
 	}
 
 	cmd.Flags().StringVarP(&cfg.file, "file", "f", "", "Path to a task definition file.")
-	cmd.Flags().StringVar(&cfg.builder, "builder", string(build.BuilderKindLocal), "Where to build the task's Docker image. Accepts: [local, remote]")
-
-	// TODO: make "remote" the default once and un-hide this flag once it is fully implemented.
-	cli.Must(cmd.Flags().MarkHidden("builder"))
+	cmd.Flags().StringVar(&cfg.builder, "builder", string(build.BuilderKindRemote), "Where to build the task's Docker image. Accepts: [local, remote]")
 
 	cli.Must(cmd.MarkFlagRequired("file"))
 

--- a/pkg/cmd/tasks/deploy/deploy.go
+++ b/pkg/cmd/tasks/deploy/deploy.go
@@ -41,7 +41,10 @@ func New(c *cli.Config) *cobra.Command {
 	}
 
 	cmd.Flags().StringVarP(&cfg.file, "file", "f", "", "Path to a task definition file.")
-	cmd.Flags().StringVar(&cfg.builder, "builder", string(build.BuilderKindRemote), "Where to build the task's Docker image. Accepts: [local, remote]")
+	cmd.Flags().StringVar(&cfg.builder, "builder", string(build.BuilderKindLocal), "Where to build the task's Docker image. Accepts: [local, remote]")
+
+	// TODO: make "remote" the default once and un-hide this flag once it is fully implemented.
+	cli.Must(cmd.Flags().MarkHidden("builder"))
 
 	cli.Must(cmd.MarkFlagRequired("file"))
 

--- a/pkg/cmd/tasks/deploy/deploy.go
+++ b/pkg/cmd/tasks/deploy/deploy.go
@@ -145,7 +145,6 @@ func run(ctx context.Context, cfg config) error {
 		}
 	}
 
-	logger.Log("Done!")
 	cmd := fmt.Sprintf("airplane execute %s", def.Slug)
 	if len(def.Parameters) > 0 {
 		cmd += " -- [parameters]"


### PR DESCRIPTION
This PR updates the logs we produce during a remote build to provide more detailed context on what is happening.

An example remote build now looks like this:

![image](https://user-images.githubusercontent.com/2907397/115802296-53ab3980-a37a-11eb-8e12-9eb36695d8d2.png)
