### PR TITLE
Fix deno cache build error

### DIFF
--- a/pkg/build/deno.go
+++ b/pkg/build/deno.go
@@ -21,7 +21,7 @@ func deno(root string, args Args) (string, error) {
 FROM {{ .Base }}
 WORKDIR /airplane
 ADD . .
-RUN deno cache {{ . }}
+RUN deno cache {{ .Entrypoint }}
 USER deno
 ENTRYPOINT ["deno", "run", "-A", "{{ .Entrypoint }}"]
 	`)


### PR DESCRIPTION
This was missing here: https://github.com/airplanedev/cli/commit/d5c8b3c0d16a7f11283c01bfa7292f0d0cd32433#diff-6f6b47986dff48c9e959a37ae27c56e71c7d8e6946752e96e3ef1838e8e9bd19L24