### PR TITLE
Add deper validation of task definition YAML

### DIFF
--- a/cmd/airplane/main.go
+++ b/cmd/airplane/main.go
@@ -7,6 +7,7 @@ import (
 	"github.com/airplanedev/cli/pkg/cmd/root"
 	"github.com/airplanedev/cli/pkg/logger"
 	"github.com/airplanedev/cli/pkg/trap"
+	"github.com/airplanedev/cli/pkg/utils"
 	"github.com/pkg/errors"
 	_ "github.com/segmentio/events/v2/text"
 )
@@ -27,9 +28,14 @@ func main() {
 			return
 		}
 
-		logger.Log("")
 		if logger.EnableDebug {
 			logger.Debug("Error: %+v", err)
+		}
+		logger.Log("")
+		if err, ok := errors.Cause(err).(utils.ErrorExplained); ok {
+			logger.Log(logger.Red(err.Error()))
+			logger.Log("")
+			logger.Log(err.ExplainError())
 		} else {
 			logger.Log(logger.Red("Error: %s", errors.Cause(err).Error()))
 		}

--- a/cmd/airplane/main.go
+++ b/cmd/airplane/main.go
@@ -29,9 +29,9 @@ func main() {
 
 		logger.Log("")
 		if logger.EnableDebug {
-			logger.Debug("  Error: %+v", err)
+			logger.Debug("Error: %+v", err)
 		} else {
-			logger.Log("  Error: %s", errors.Cause(err).Error())
+			logger.Log(logger.Red("Error: %s", errors.Cause(err).Error()))
 		}
 		logger.Log("")
 

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/MakeNowJust/heredoc v1.0.0
 	github.com/Microsoft/hcsshim v0.8.15 // indirect
 	github.com/airplanedev/archiver v1.1.3-0.20210415184012-094191384ed3
+	github.com/alecthomas/jsonschema v0.0.0-20210413112511-5c9c23bdc720 // indirect
 	github.com/containerd/continuity v0.0.0-20210313171317-968621f0704d // indirect
 	github.com/docker/cli v20.10.6+incompatible
 	github.com/docker/docker v20.10.5+incompatible
@@ -26,6 +27,7 @@ require (
 	github.com/spf13/cobra v1.1.3
 	github.com/stretchr/testify v1.6.1
 	github.com/ulikunitz/xz v0.5.10 // indirect
+	github.com/xeipuuv/gojsonschema v1.2.0 // indirect
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	golang.org/x/sys v0.0.0-20210309074719-68d13333faf2 // indirect
 	golang.org/x/text v0.3.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -143,6 +143,8 @@ github.com/airplanedev/archiver v1.1.3-0.20210415184012-094191384ed3 h1:3dDLthSJ
 github.com/airplanedev/archiver v1.1.3-0.20210415184012-094191384ed3/go.mod h1:Ivrbszdwkt97U/lZecL5Sh3qlWOHcQk7HatXFTCCdZg=
 github.com/alcortesm/tgz v0.0.0-20161220082320-9c5fe88206d7 h1:uSoVVbwJiQipAclBbw+8quDsfcvFjOpI5iCf4p/cqCs=
 github.com/alcortesm/tgz v0.0.0-20161220082320-9c5fe88206d7/go.mod h1:6zEj6s6u/ghQa61ZWa/C2Aw3RkjiTBOix7dkqa1VLIs=
+github.com/alecthomas/jsonschema v0.0.0-20210413112511-5c9c23bdc720 h1:eGgkuR6dLpW0rvJCOH6illGPbxyndL2J3f7wDI2qCsE=
+github.com/alecthomas/jsonschema v0.0.0-20210413112511-5c9c23bdc720/go.mod h1:/n6+1/DWPltRLWL/VKyUxg6tzsl5kHUCcraimt4vr60=
 github.com/alecthomas/kingpin v2.2.6+incompatible/go.mod h1:59OFYbFVLKQKq+mqrL6Rw5bR0c3ACQaawgXx0QYndlE=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
@@ -621,6 +623,8 @@ github.com/hashicorp/uuid v0.0.0-20160311170451-ebb0a03e909c/go.mod h1:fHzc09Uny
 github.com/hinshun/vt10x v0.0.0-20180616224451-1954e6464174 h1:WlZsjVhE8Af9IcZDGgJGQpNflI3+MJSBhsgT5PCtzBQ=
 github.com/hinshun/vt10x v0.0.0-20180616224451-1954e6464174/go.mod h1:DqJ97dSdRW1W22yXSB90986pcOyQ7r45iio1KN2ez1A=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
+github.com/iancoleman/orderedmap v0.0.0-20190318233801-ac98e3ecb4b0 h1:i462o439ZjprVSFSZLZxcsoAe592sZB1rci2Z8j4wdk=
+github.com/iancoleman/orderedmap v0.0.0-20190318233801-ac98e3ecb4b0/go.mod h1:N0Wam8K1arqPXNWjMo21EXnBPOPp36vB07FNRdD2geA=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/imdario/mergo v0.3.8/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
@@ -997,6 +1001,7 @@ github.com/stretchr/testify v0.0.0-20180303142811-b89eecf5ca5d/go.mod h1:a8OnRci
 github.com/stretchr/testify v1.2.1/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/stretchr/testify v1.3.1-0.20190311161405-34c6fa2dc709/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
@@ -1055,9 +1060,13 @@ github.com/xanzy/go-gitlab v0.31.0/go.mod h1:sPLojNBn68fMUWSxIJtdVVIP8uSBYqesTfD
 github.com/xanzy/go-gitlab v0.32.0/go.mod h1:sPLojNBn68fMUWSxIJtdVVIP8uSBYqesTfDUseX11Ug=
 github.com/xanzy/ssh-agent v0.2.1 h1:TCbipTQL2JiiCprBWx9frJ2eJlCYT00NmctrHxVAr70=
 github.com/xanzy/ssh-agent v0.2.1/go.mod h1:mLlQY/MoOhWBj+gOGMQkOeiEvkx+8pJSI+0Bx9h2kr4=
+github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f h1:J9EGpcZtP0E/raorCMxlFGSTBrsSlaDGf3jU/qvAE2c=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
+github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 h1:EzJWgHovont7NscjpAxXsDA8S8BMYve8Y5+7cuRE7R0=
 github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:GwrjFmJcFw6At/Gs6z4yjiIwzuJ1/+UwLxMQDVQXShQ=
 github.com/xeipuuv/gojsonschema v0.0.0-20180618132009-1d523034197f/go.mod h1:5yf86TLmAcydyeJq5YvxkGPE2fm/u4myDekKRoLuqhs=
+github.com/xeipuuv/gojsonschema v1.2.0 h1:LhYJRs+L4fBtjZUfuSZIKGeVu0QRy8e5Xi7D17UxZ74=
+github.com/xeipuuv/gojsonschema v1.2.0/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQluxsYJ78Id3Y=
 github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 h1:nIPpBwaJSVYIxUFsDv3M8ofmx9yWTog9BfvIu0q41lo=
 github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8/go.mod h1:HUYIGzjTL3rfEspMxjDjgmT5uz5wzYJKVo23qUhYTos=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=

--- a/pkg/taskdir/taskdef.go
+++ b/pkg/taskdir/taskdef.go
@@ -76,13 +76,13 @@ func (this TaskDirectory) ReadDefinition() (Definition, error) {
 		switch err := errors.Cause(err).(type) {
 		case ErrInvalidYAML:
 			logger.Log(logger.Red("\nError reading %s: invalid YAML", defPath))
-			logger.Log("\nTask definition reference: %s", taskDefDocURL)
+			logger.Log("\nFor more information on the task definition format, see the docs:\n%s", taskDefDocURL)
 		case ErrSchemaValidation:
 			logger.Log(logger.Red("\nError reading %s:\n", defPath))
 			for _, verr := range err.Errors {
 				logger.Log("  %s: %s", verr.Field(), verr.Description())
 			}
-			logger.Log("\nTask definition reference: %s", taskDefDocURL)
+			logger.Log("\nFor more information on the task definition format, see the docs:\n%s", taskDefDocURL)
 		}
 		return Definition{}, errors.Wrapf(err, "error reading %s", defPath)
 	}

--- a/pkg/taskdir/taskdef.go
+++ b/pkg/taskdir/taskdef.go
@@ -75,16 +75,16 @@ func (this TaskDirectory) ReadDefinition() (Definition, error) {
 		// Print any "expected" validation errors
 		switch err := errors.Cause(err).(type) {
 		case ErrInvalidYAML:
-			logger.Log(logger.Red("\nError reading %s: invalid YAML", defPath))
+			logger.Log("\nError reading %s: invalid YAML", defPath)
 			logger.Log("\nFor more information on the task definition format, see the docs:\n%s", taskDefDocURL)
 		case ErrSchemaValidation:
-			logger.Log(logger.Red("\nError reading %s:\n", defPath))
+			logger.Log("\nError reading %s:\n", defPath)
 			for _, verr := range err.Errors {
 				logger.Log("  %s: %s", verr.Field(), verr.Description())
 			}
 			logger.Log("\nFor more information on the task definition format, see the docs:\n%s", taskDefDocURL)
 		}
-		return Definition{}, errors.Wrapf(err, "error reading %s", defPath)
+		return Definition{}, errors.Errorf("reading %s: %s", defPath, errors.Cause(err))
 	}
 
 	var def Definition

--- a/pkg/taskdir/validate.go
+++ b/pkg/taskdir/validate.go
@@ -18,7 +18,7 @@ type ErrSchemaValidation struct {
 }
 
 func (this ErrSchemaValidation) Error() string {
-	return "failed validation against JSON schema"
+	return "invalid YAML format"
 }
 
 // ValidateYAML checks that YAML data matches the schema defined by schemaObj

--- a/pkg/taskdir/validate.go
+++ b/pkg/taskdir/validate.go
@@ -1,0 +1,46 @@
+package taskdir
+
+import (
+	"github.com/alecthomas/jsonschema"
+	"github.com/pkg/errors"
+	"github.com/xeipuuv/gojsonschema"
+	"gopkg.in/yaml.v3"
+)
+
+type ErrInvalidYAML struct{}
+
+func (this ErrInvalidYAML) Error() string {
+	return "invalid YAML"
+}
+
+type ErrSchemaValidation struct {
+	Errors []gojsonschema.ResultError
+}
+
+func (this ErrSchemaValidation) Error() string {
+	return "failed validation against JSON schema"
+}
+
+// ValidateYAML checks that YAML data matches the schema defined by schemaObj
+// Returns ErrInvalidYAML if not valid YAML and ErrSchemaValidation if YAML doesn't match schemaObj
+func ValidateYAML(data []byte, schemaObj interface{}) error {
+	var obj interface{}
+	if err := yaml.Unmarshal(data, &obj); err != nil {
+		return errors.WithStack(ErrInvalidYAML{})
+	}
+
+	r := &jsonschema.Reflector{PreferYAMLSchema: true}
+	schemaLoader := gojsonschema.NewGoLoader(r.Reflect(schemaObj))
+	docLoader := gojsonschema.NewGoLoader(obj)
+
+	result, err := gojsonschema.Validate(schemaLoader, docLoader)
+	if err != nil {
+		return errors.Wrap(err, "validating schema")
+	}
+
+	if !result.Valid() {
+		return errors.WithStack(ErrSchemaValidation{Errors: result.Errors()})
+	}
+
+	return nil
+}

--- a/pkg/utils/errors.go
+++ b/pkg/utils/errors.go
@@ -1,0 +1,6 @@
+package utils
+
+type ErrorExplained interface {
+	Error() string
+	ExplainError() string
+}


### PR DESCRIPTION
Uses jsonschema to (1) generate a schema from Definition{} and (2)
report on any errors.

This is meant as a lightweight validation layer to provide the end user
with better hints - if something isn't caught here, the server will
still error.

To support this, this introduces `utils.ErrorExplained` for better error
printing when we want to print out err.Error() followed by err.ExplainError()

Invalid YAML:

```
Error reading ../task-playground/create-validation/airplane.yml: invalid YAML

For more information on the task definition format, see the docs:
https://docs.airplane.dev/reference/task-definition-reference
```

Map instead of array:

```
Error reading ../task-playground/create-validation/airplane.yml

parameters: Invalid type. Expected: array, given: object

For more information on the task definition format, see the docs:
https://docs.airplane.dev/reference/task-definition-reference
```

Missing fields:

```
Error reading ../task-playground/create-validation/airplane.yml

parameters.0: type is required

For more information on the task definition format, see the docs:
https://docs.airplane.dev/reference/task-definition-reference
```

Invalid type:

```
Error reading ../task-playground/create-validation/airplane.yml

parameters.0.type: Invalid type. Expected: string, given: integer

For more information on the task definition format, see the docs:
https://docs.airplane.dev/reference/task-definition-referenc
```

Resolves AIR-607