### PR TITLE
Remove extra newline in validation message if there are no specific errors

### DIFF
--- a/pkg/taskdir/taskdef.go
+++ b/pkg/taskdir/taskdef.go
@@ -77,7 +77,10 @@ func (this errReadDefinition) Error() string {
 func (this errReadDefinition) ExplainError() string {
 	msgs := []string{}
 	msgs = append(msgs, this.errorMsgs...)
-	msgs = append(msgs, fmt.Sprintf("\nFor more information on the task definition format, see the docs:\n%s", taskDefDocURL))
+	if len(this.errorMsgs) > 0 {
+		msgs = append(msgs, "")
+	}
+	msgs = append(msgs, fmt.Sprintf("For more information on the task definition format, see the docs:\n%s", taskDefDocURL))
 	return strings.Join(msgs, "\n")
 }
 


### PR DESCRIPTION
If there are no specific errorMsgs, this avoids having an extra newline
printed.
