### PR TITLE
Change YAML file format

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -9,38 +9,38 @@ import (
 
 // CreateTaskRequest creates a new task.
 type CreateTaskRequest struct {
-	Slug           string            `json:"slug"`
-	Name           string            `json:"name"`
-	Description    string            `json:"description"`
-	Image          string            `json:"image"`
-	Command        []string          `json:"command"`
-	Arguments      []string          `json:"arguments"`
-	Parameters     Parameters        `json:"parameters"`
-	Constraints    RunConstraints    `json:"constraints"`
-	Env            TaskEnv           `json:"env"`
-	ResourceLimits map[string]string `json:"resourceLimits"`
-	Kind           string            `json:"kind"`
-	KindOptions    map[string]string `json:"kindOptions"`
-	Repo           string            `json:"repo"`
+	Slug             string            `json:"slug"`
+	Name             string            `json:"name"`
+	Description      string            `json:"description"`
+	Image            string            `json:"image"`
+	Command          []string          `json:"command"`
+	Arguments        []string          `json:"arguments"`
+	Parameters       Parameters        `json:"parameters"`
+	Constraints      RunConstraints    `json:"constraints"`
+	Env              TaskEnv           `json:"env"`
+	ResourceRequests map[string]string `json:"resourceRequests"`
+	Kind             string            `json:"kind"`
+	KindOptions      map[string]string `json:"kindOptions"`
+	Repo             string            `json:"repo"`
 	// TODO(amir): friendly type here (120s, 5m ...)
 	Timeout int `json:"timeout"`
 }
 
 // UpdateTaskRequest updates a task.
 type UpdateTaskRequest struct {
-	Slug           string            `json:"slug" yaml:"-"`
-	Name           string            `json:"name" yaml:"name"`
-	Description    string            `json:"description" yaml:"description"`
-	Image          string            `json:"image" yaml:"image"`
-	Command        []string          `json:"command" yaml:"command"`
-	Arguments      []string          `json:"arguments" yaml:"arguments"`
-	Parameters     Parameters        `json:"parameters" yaml:"parameters"`
-	Constraints    RunConstraints    `json:"constraints" yaml:"constraints"`
-	Env            TaskEnv           `json:"env" yaml:"env"`
-	ResourceLimits map[string]string `json:"resourceLimits" yaml:"resourceLimits"`
-	Kind           string            `json:"kind" yaml:"builder"`
-	KindOptions    map[string]string `json:"kindOptions" yaml:"builderConfig"`
-	Repo           string            `json:"repo" yaml:"repo"`
+	Slug             string            `json:"slug" yaml:"-"`
+	Name             string            `json:"name" yaml:"name"`
+	Description      string            `json:"description" yaml:"description"`
+	Image            string            `json:"image" yaml:"image"`
+	Command          []string          `json:"command" yaml:"command"`
+	Arguments        []string          `json:"arguments" yaml:"arguments"`
+	Parameters       Parameters        `json:"parameters" yaml:"parameters"`
+	Constraints      RunConstraints    `json:"constraints" yaml:"constraints"`
+	Env              TaskEnv           `json:"env" yaml:"env"`
+	ResourceRequests map[string]string `json:"resourceRequests" yaml:"resourceRequests"`
+	Kind             string            `json:"kind" yaml:"builder"`
+	KindOptions      map[string]string `json:"kindOptions" yaml:"builderConfig"`
+	Repo             string            `json:"repo" yaml:"repo"`
 	// TODO(amir): friendly type here (120s, 5m ...)
 	Timeout int `json:"timeout" yaml:"timeout"`
 }
@@ -243,26 +243,26 @@ func (this *EnvVarValue) UnmarshalYAML(node *yaml.Node) error {
 
 // Task represents a task.
 type Task struct {
-	ID             string         `json:"taskID" yaml:"id"`
-	Name           string         `json:"name" yaml:"name"`
-	Slug           string         `json:"slug" yaml:"slug"`
-	Description    string         `json:"description" yaml:"description"`
-	Image          string         `json:"image" yaml:"image"`
-	Command        []string       `json:"command" yaml:"command"`
-	Arguments      []string       `json:"arguments" yaml:"arguments"`
-	Parameters     Parameters     `json:"parameters" yaml:"parameters"`
-	Constraints    RunConstraints `json:"constraints" yaml:"constraints"`
-	Env            TaskEnv        `json:"env" yaml:"env"`
-	ResourceLimits ResourceLimits `json:"resourceLimits" yaml:"resourceLimits"`
-	Kind           string         `json:"kind" yaml:"kind"`
-	KindOptions    KindOptions    `json:"kindOptions" yaml:"kindOptions"`
-	Repo           string         `json:"repo" yaml:"repo"`
-	Timeout        int            `json:"timeout" yaml:"timeout"`
+	ID               string           `json:"taskID" yaml:"id"`
+	Name             string           `json:"name" yaml:"name"`
+	Slug             string           `json:"slug" yaml:"slug"`
+	Description      string           `json:"description" yaml:"description"`
+	Image            string           `json:"image" yaml:"image"`
+	Command          []string         `json:"command" yaml:"command"`
+	Arguments        []string         `json:"arguments" yaml:"arguments"`
+	Parameters       Parameters       `json:"parameters" yaml:"parameters"`
+	Constraints      RunConstraints   `json:"constraints" yaml:"constraints"`
+	Env              TaskEnv          `json:"env" yaml:"env"`
+	ResourceRequests ResourceRequests `json:"resourceRequests" yaml:"resourceRequests"`
+	Kind             string           `json:"kind" yaml:"kind"`
+	KindOptions      KindOptions      `json:"kindOptions" yaml:"kindOptions"`
+	Repo             string           `json:"repo" yaml:"repo"`
+	Timeout          int              `json:"timeout" yaml:"timeout"`
 }
 
 type KindOptions map[string]string
 
-type ResourceLimits map[string]string
+type ResourceRequests map[string]string
 
 // Values represent parameters values.
 //

--- a/pkg/build/local.go
+++ b/pkg/build/local.go
@@ -22,10 +22,14 @@ func Local(ctx context.Context, client *api.Client, dir taskdir.TaskDirectory, d
 		return err
 	}
 
+	kind, options, err := def.GetKindAndOptions()
+	if err != nil {
+		return err
+	}
 	b, err := New(LocalConfig{
 		Root:    dir.DefinitionRootPath(),
-		Builder: def.Kind,
-		Args:    Args(def.KindOptions),
+		Builder: kind,
+		Args:    Args(options),
 		Auth: &RegistryAuth{
 			Token: registry.Token,
 			Repo:  registry.Repo,

--- a/pkg/build/local.go
+++ b/pkg/build/local.go
@@ -7,10 +7,11 @@ import (
 	"github.com/airplanedev/cli/pkg/configs"
 	"github.com/airplanedev/cli/pkg/logger"
 	"github.com/airplanedev/cli/pkg/taskdir"
+	"github.com/airplanedev/cli/pkg/taskdir/definitions"
 	"github.com/pkg/errors"
 )
 
-func Local(ctx context.Context, client *api.Client, dir taskdir.TaskDirectory, def taskdir.Definition, taskID string) error {
+func Local(ctx context.Context, client *api.Client, dir taskdir.TaskDirectory, def definitions.Definition, taskID string) error {
 	registry, err := client.GetRegistryToken(ctx)
 	if err != nil {
 		return errors.Wrap(err, "getting registry token")
@@ -51,7 +52,7 @@ func Local(ctx context.Context, client *api.Client, dir taskdir.TaskDirectory, d
 
 // Retreives a build env from def - looks for env vars starting with BUILD_ and either uses the
 // string literal or looks up the config value.
-func getBuildEnv(ctx context.Context, client *api.Client, def taskdir.Definition) (map[string]string, error) {
+func getBuildEnv(ctx context.Context, client *api.Client, def definitions.Definition) (map[string]string, error) {
 	buildEnv := make(map[string]string)
 	for k, v := range def.Env {
 		if v.Value != nil {

--- a/pkg/build/local.go
+++ b/pkg/build/local.go
@@ -23,8 +23,8 @@ func Local(ctx context.Context, client *api.Client, dir taskdir.TaskDirectory, d
 
 	b, err := New(LocalConfig{
 		Root:    dir.DefinitionRootPath(),
-		Builder: def.Builder,
-		Args:    Args(def.BuilderConfig),
+		Builder: def.Kind,
+		Args:    Args(def.KindOptions),
 		Auth: &RegistryAuth{
 			Token: registry.Token,
 			Repo:  registry.Repo,

--- a/pkg/build/remote.go
+++ b/pkg/build/remote.go
@@ -74,7 +74,7 @@ func archiveTaskDir(dir taskdir.TaskDirectory, archivePath string) error {
 	if err != nil {
 		return err
 	}
-	arch.Tar.IncludeFunc, err = getIgnoreFunc(dir.DefinitionRootPath(), def.Builder)
+	arch.Tar.IncludeFunc, err = getIgnoreFunc(dir.DefinitionRootPath(), def.Kind)
 	if err != nil {
 		return err
 	}

--- a/pkg/build/remote.go
+++ b/pkg/build/remote.go
@@ -74,7 +74,11 @@ func archiveTaskDir(dir taskdir.TaskDirectory, archivePath string) error {
 	if err != nil {
 		return err
 	}
-	arch.Tar.IncludeFunc, err = getIgnoreFunc(dir.DefinitionRootPath(), def.Kind)
+	builder, _, err := def.GetKindAndOptions()
+	if err != nil {
+		return err
+	}
+	arch.Tar.IncludeFunc, err = getIgnoreFunc(dir.DefinitionRootPath(), builder)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/tasks/deploy/deploy.go
+++ b/pkg/cmd/tasks/deploy/deploy.go
@@ -92,8 +92,8 @@ func run(ctx context.Context, cfg config) error {
 			Constraints:    def.Constraints,
 			Env:            def.Env,
 			ResourceLimits: def.ResourceLimits,
-			Kind:           def.Builder,
-			KindOptions:    def.BuilderConfig,
+			Kind:           def.Kind,
+			KindOptions:    def.KindOptions,
 			Repo:           def.Repo,
 			Timeout:        def.Timeout,
 		})
@@ -117,8 +117,8 @@ func run(ctx context.Context, cfg config) error {
 			Constraints:    def.Constraints,
 			Env:            def.Env,
 			ResourceLimits: def.ResourceLimits,
-			Kind:           def.Builder,
-			KindOptions:    def.BuilderConfig,
+			Kind:           def.Kind,
+			KindOptions:    def.KindOptions,
 			Repo:           def.Repo,
 			Timeout:        def.Timeout,
 		})
@@ -132,7 +132,7 @@ func run(ctx context.Context, cfg config) error {
 		return errors.Wrap(err, "getting task")
 	}
 
-	if def.Builder != "" {
+	if def.Kind != "" {
 		switch builder {
 		case build.BuilderKindLocal:
 			if err := build.Local(ctx, client, dir, def, taskID); err != nil {

--- a/pkg/cmd/tasks/deploy/deploy.go
+++ b/pkg/cmd/tasks/deploy/deploy.go
@@ -94,20 +94,20 @@ func run(ctx context.Context, cfg config) error {
 		// This task already exists, so we update it:
 		logger.Log("Updating task...")
 		res, err := client.UpdateTask(ctx, api.UpdateTaskRequest{
-			Slug:           def.Slug,
-			Name:           def.Name,
-			Description:    def.Description,
-			Image:          image,
-			Command:        command,
-			Arguments:      def.Arguments,
-			Parameters:     def.Parameters,
-			Constraints:    def.Constraints,
-			Env:            def.Env,
-			ResourceLimits: def.ResourceLimits,
-			Kind:           kind,
-			KindOptions:    kindOptions,
-			Repo:           def.Repo,
-			Timeout:        def.Timeout,
+			Slug:             def.Slug,
+			Name:             def.Name,
+			Description:      def.Description,
+			Image:            image,
+			Command:          command,
+			Arguments:        def.Arguments,
+			Parameters:       def.Parameters,
+			Constraints:      def.Constraints,
+			Env:              def.Env,
+			ResourceRequests: def.ResourceRequests,
+			Kind:             kind,
+			KindOptions:      kindOptions,
+			Repo:             def.Repo,
+			Timeout:          def.Timeout,
 		})
 		if err != nil {
 			return errors.Wrapf(err, "updating task %s", def.Slug)
@@ -119,20 +119,20 @@ func run(ctx context.Context, cfg config) error {
 		// A task with this slug does not exist, so we should create one.
 		logger.Log("Creating task...")
 		res, err := client.CreateTask(ctx, api.CreateTaskRequest{
-			Slug:           def.Slug,
-			Name:           def.Name,
-			Description:    def.Description,
-			Image:          image,
-			Command:        command,
-			Arguments:      def.Arguments,
-			Parameters:     def.Parameters,
-			Constraints:    def.Constraints,
-			Env:            def.Env,
-			ResourceLimits: def.ResourceLimits,
-			Kind:           kind,
-			KindOptions:    kindOptions,
-			Repo:           def.Repo,
-			Timeout:        def.Timeout,
+			Slug:             def.Slug,
+			Name:             def.Name,
+			Description:      def.Description,
+			Image:            image,
+			Command:          command,
+			Arguments:        def.Arguments,
+			Parameters:       def.Parameters,
+			Constraints:      def.Constraints,
+			Env:              def.Env,
+			ResourceRequests: def.ResourceRequests,
+			Kind:             kind,
+			KindOptions:      kindOptions,
+			Repo:             def.Repo,
+			Timeout:          def.Timeout,
 		})
 		if err != nil {
 			return errors.Wrapf(err, "creating task %s", def.Slug)

--- a/pkg/cmd/tasks/deploy/deploy.go
+++ b/pkg/cmd/tasks/deploy/deploy.go
@@ -80,6 +80,13 @@ func run(ctx context.Context, cfg config) error {
 		return err
 	}
 
+	var image string
+	var command []string
+	if def.Manual != nil {
+		image = def.Manual.Image
+		command = def.Manual.Command
+	}
+
 	var taskID string
 	var taskRevisionID string
 	task, err := client.GetTask(ctx, def.Slug)
@@ -90,8 +97,8 @@ func run(ctx context.Context, cfg config) error {
 			Slug:           def.Slug,
 			Name:           def.Name,
 			Description:    def.Description,
-			Image:          def.Image,
-			Command:        def.Command,
+			Image:          image,
+			Command:        command,
 			Arguments:      def.Arguments,
 			Parameters:     def.Parameters,
 			Constraints:    def.Constraints,
@@ -115,8 +122,8 @@ func run(ctx context.Context, cfg config) error {
 			Slug:           def.Slug,
 			Name:           def.Name,
 			Description:    def.Description,
-			Image:          def.Image,
-			Command:        def.Command,
+			Image:          image,
+			Command:        command,
 			Arguments:      def.Arguments,
 			Parameters:     def.Parameters,
 			Constraints:    def.Constraints,

--- a/pkg/cmd/tasks/deploy/deploy.go
+++ b/pkg/cmd/tasks/deploy/deploy.go
@@ -75,6 +75,11 @@ func run(ctx context.Context, cfg config) error {
 		return err
 	}
 
+	kind, kindOptions, err := def.GetKindAndOptions()
+	if err != nil {
+		return err
+	}
+
 	var taskID string
 	var taskRevisionID string
 	task, err := client.GetTask(ctx, def.Slug)
@@ -92,8 +97,8 @@ func run(ctx context.Context, cfg config) error {
 			Constraints:    def.Constraints,
 			Env:            def.Env,
 			ResourceLimits: def.ResourceLimits,
-			Kind:           def.Kind,
-			KindOptions:    def.KindOptions,
+			Kind:           kind,
+			KindOptions:    kindOptions,
 			Repo:           def.Repo,
 			Timeout:        def.Timeout,
 		})
@@ -117,8 +122,8 @@ func run(ctx context.Context, cfg config) error {
 			Constraints:    def.Constraints,
 			Env:            def.Env,
 			ResourceLimits: def.ResourceLimits,
-			Kind:           def.Kind,
-			KindOptions:    def.KindOptions,
+			Kind:           kind,
+			KindOptions:    kindOptions,
 			Repo:           def.Repo,
 			Timeout:        def.Timeout,
 		})
@@ -132,7 +137,7 @@ func run(ctx context.Context, cfg config) error {
 		return errors.Wrap(err, "getting task")
 	}
 
-	if def.Kind != "" {
+	if kind != "" {
 		switch builder {
 		case build.BuilderKindLocal:
 			if err := build.Local(ctx, client, dir, def, taskID); err != nil {

--- a/pkg/cmd/tasks/deploy/predeploy.go
+++ b/pkg/cmd/tasks/deploy/predeploy.go
@@ -9,13 +9,13 @@ import (
 	"github.com/airplanedev/cli/pkg/api"
 	"github.com/airplanedev/cli/pkg/configs"
 	"github.com/airplanedev/cli/pkg/logger"
-	"github.com/airplanedev/cli/pkg/taskdir"
+	"github.com/airplanedev/cli/pkg/taskdir/definitions"
 	"github.com/airplanedev/cli/pkg/utils"
 	"github.com/pkg/errors"
 )
 
 // ensureConfigsExist checks for config references in env and asks users to create any missing ones
-func ensureConfigsExist(ctx context.Context, client *api.Client, def taskdir.Definition) error {
+func ensureConfigsExist(ctx context.Context, client *api.Client, def definitions.Definition) error {
 	// Check if configs exist
 	for k, v := range def.Env {
 		if v.Config != nil {

--- a/pkg/cmd/tasks/initcmd/sample.go
+++ b/pkg/cmd/tasks/initcmd/sample.go
@@ -57,27 +57,30 @@ func initFromSample(ctx context.Context, cfg config) error {
 		outputdir = path.Base(path.Dir(dir.DefinitionPath()))
 	}
 
-	// Rename the sample definition to match the filename in the `-f` argument.
-	// This is done to maintain semantic consistency with the other kinds of
-	// init, but is not strictly necessary.
-	defname := path.Base(dir.DefinitionPath())
-	if cfg.file != "" && defname != path.Base(cfg.file) {
-		defname = path.Base(cfg.file)
-		if err := os.Rename(
-			dir.DefinitionPath(),
-			path.Join(path.Dir(dir.DefinitionPath()), defname),
-		); err != nil {
-			return errors.Wrap(err, "renaming task definitino")
-		}
-	}
-
 	// Copy the sample code from the temporary directory into the user's
 	// local directory.
 	if err := copy.Copy(dir.DefinitionRootPath(), outputdir); err != nil {
 		return errors.Wrap(err, "copying sample directory")
 	}
 
+	// Remove the original def file.
+	if err := os.Remove(path.Join(outputdir, path.Base(dir.DefinitionPath()))); err != nil {
+		return errors.Wrap(err, "removing original def")
+	}
+
+	// Write the new definition to match the filename in the `-f` argument.
+	// This is done to maintain semantic consistency with the other kinds of
+	// init, but is not strictly necessary.
+	defname := path.Base(dir.DefinitionPath())
+	if cfg.file != "" && defname != path.Base(cfg.file) {
+		defname = path.Base(cfg.file)
+	}
 	file := path.Join(outputdir, defname)
+	oDir, err := taskdir.New(file)
+	if oDir.WriteDefinition(def); err != nil {
+		return errors.Wrap(err, "rewriting task definition")
+	}
+
 	logger.Log(`
 An Airplane task definition for '%s' has been created!
 

--- a/pkg/cmd/tasks/initcmd/sample.go
+++ b/pkg/cmd/tasks/initcmd/sample.go
@@ -41,9 +41,7 @@ func initFromSample(ctx context.Context, cfg config) error {
 		return errors.Wrap(err, "getting unique slug")
 	}
 	if r.Slug != def.Slug {
-		if err := dir.WriteSlug(r.Slug); err != nil {
-			return err
-		}
+		def.Slug = r.Slug
 	}
 
 	var outputdir string

--- a/pkg/cmd/tasks/initcmd/scaffolders/scaffolders.go
+++ b/pkg/cmd/tasks/initcmd/scaffolders/scaffolders.go
@@ -5,12 +5,12 @@ import (
 	"path"
 	"path/filepath"
 
-	"github.com/airplanedev/cli/pkg/taskdir"
+	"github.com/airplanedev/cli/pkg/taskdir/definitions"
 	"github.com/pkg/errors"
 )
 
 type RuntimeScaffolder interface {
-	GenerateFiles(def taskdir.Definition, filemap map[string][]byte) error
+	GenerateFiles(def definitions.Definition, filemap map[string][]byte) error
 }
 
 // Deno
@@ -21,7 +21,7 @@ type DenoScaffolder struct {
 
 var _ RuntimeScaffolder = DenoScaffolder{}
 
-func (this DenoScaffolder) GenerateFiles(def taskdir.Definition, filemap map[string][]byte) error {
+func (this DenoScaffolder) GenerateFiles(def definitions.Definition, filemap map[string][]byte) error {
 	// Entrypoint
 	filemap[path.Join(def.Root, this.Entrypoint)] = []byte(`console.log("Hello world!");
 `)
@@ -36,7 +36,7 @@ type DockerfileScaffolder struct {
 
 var _ RuntimeScaffolder = DockerfileScaffolder{}
 
-func (this DockerfileScaffolder) GenerateFiles(def taskdir.Definition, filemap map[string][]byte) error {
+func (this DockerfileScaffolder) GenerateFiles(def definitions.Definition, filemap map[string][]byte) error {
 	// Dockerfile
 	filemap[path.Join(def.Root, this.Dockerfile)] = []byte(`FROM ubuntu:20.10
 
@@ -53,7 +53,7 @@ type GoScaffolder struct {
 
 var _ RuntimeScaffolder = GoScaffolder{}
 
-func (this GoScaffolder) GenerateFiles(def taskdir.Definition, filemap map[string][]byte) error {
+func (this GoScaffolder) GenerateFiles(def definitions.Definition, filemap map[string][]byte) error {
 	// Entrypoint
 	filemap[path.Join(def.Root, this.Entrypoint)] = []byte(`package main
 
@@ -77,7 +77,7 @@ type NodeScaffolder struct {
 
 var _ RuntimeScaffolder = NodeScaffolder{}
 
-func (this NodeScaffolder) GenerateFiles(def taskdir.Definition, filemap map[string][]byte) error {
+func (this NodeScaffolder) GenerateFiles(def definitions.Definition, filemap map[string][]byte) error {
 	// Entrypoint
 	filemap[path.Join(def.Root, this.Entrypoint)] = []byte(`const main = (args) => {
 	console.log("Hello world!")
@@ -109,7 +109,7 @@ type PythonScaffolder struct {
 
 var _ RuntimeScaffolder = PythonScaffolder{}
 
-func (this PythonScaffolder) GenerateFiles(def taskdir.Definition, filemap map[string][]byte) error {
+func (this PythonScaffolder) GenerateFiles(def definitions.Definition, filemap map[string][]byte) error {
 	// Entrypoint
 	filemap[path.Join(def.Root, this.Entrypoint)] = []byte(`print("Hello world!")
 `)

--- a/pkg/cmd/tasks/initcmd/scratch.go
+++ b/pkg/cmd/tasks/initcmd/scratch.go
@@ -59,7 +59,7 @@ func initFromScratch(ctx context.Context, cfg config) error {
 		def.Image = "alpine:3"
 		def.Command = []string{"echo", `"Hello World"`}
 	} else {
-		if def.Builder, def.BuilderConfig, scaffolder, err = defaultRuntimeConfig(runtime); err != nil {
+		if def.Kind, def.KindOptions, scaffolder, err = defaultRuntimeConfig(runtime); err != nil {
 			return err
 		}
 	}

--- a/pkg/cmd/tasks/initcmd/scratch.go
+++ b/pkg/cmd/tasks/initcmd/scratch.go
@@ -6,7 +6,6 @@ import (
 	"os"
 
 	"github.com/AlecAivazis/survey/v2"
-	"github.com/airplanedev/cli/pkg/api"
 	"github.com/airplanedev/cli/pkg/cmd/tasks/initcmd/scaffolders"
 	"github.com/airplanedev/cli/pkg/logger"
 	"github.com/airplanedev/cli/pkg/taskdir"
@@ -60,7 +59,7 @@ func initFromScratch(ctx context.Context, cfg config) error {
 		def.Image = "alpine:3"
 		def.Command = []string{"echo", `"Hello World"`}
 	} else {
-		if def.Kind, def.KindOptions, scaffolder, err = defaultRuntimeConfig(runtime); err != nil {
+		if scaffolder, err = defaultRuntimeConfig(runtime, &def); err != nil {
 			return err
 		}
 	}
@@ -82,33 +81,28 @@ Once you are ready, deploy it to Airplane with:
 	return nil
 }
 
-func defaultRuntimeConfig(runtime runtimeKind) (string, api.KindOptions, scaffolders.RuntimeScaffolder, error) {
+func defaultRuntimeConfig(runtime runtimeKind, def *definitions.Definition) (scaffolders.RuntimeScaffolder, error) {
 	// TODO: let folks configure the following configuration
 	switch runtime {
 	case runtimeKindDeno:
-		return "deno", api.KindOptions{
-			"entrypoint": "main.ts",
-		}, scaffolders.DenoScaffolder{Entrypoint: "main.ts"}, nil
+		def.Deno.Entrypoint = "main.ts"
+		return scaffolders.DenoScaffolder{Entrypoint: "main.ts"}, nil
 	case runtimeKindDockerfile:
-		return "docker", api.KindOptions{
-			"dockerfile": "Dockerfile",
-		}, scaffolders.DockerfileScaffolder{Dockerfile: "Dockerfile"}, nil
+		def.Docker.Dockerfile = "Dockerfile"
+		return scaffolders.DockerfileScaffolder{Dockerfile: "Dockerfile"}, nil
 	case runtimeKindGo:
-		return "go", api.KindOptions{
-			"entrypoint": "main.go",
-		}, scaffolders.GoScaffolder{Entrypoint: "main.go"}, nil
+		def.Go.Entrypoint = "main.go"
+		return scaffolders.GoScaffolder{Entrypoint: "main.go"}, nil
 	case runtimeKindNode:
-		return "node", api.KindOptions{
-			"entrypoint":  "main.js",
-			"language":    "javascript",
-			"nodeVersion": "15",
-		}, scaffolders.NodeScaffolder{Entrypoint: "main.js"}, nil
+		def.Node.Entrypoint = "main.js"
+		def.Node.Language = "javascript"
+		def.Node.NodeVersion = "15"
+		return scaffolders.NodeScaffolder{Entrypoint: "main.js"}, nil
 	case runtimeKindPython:
-		return "python", api.KindOptions{
-			"entrypoint": "main.py",
-		}, scaffolders.PythonScaffolder{Entrypoint: "main.py"}, nil
+		def.Python.Entrypoint = "main.py"
+		return scaffolders.PythonScaffolder{Entrypoint: "main.py"}, nil
 	default:
-		return "", nil, nil, errors.Errorf("unknown runtime: %s", runtime)
+		return nil, errors.Errorf("unknown runtime: %s", runtime)
 	}
 }
 

--- a/pkg/cmd/tasks/initcmd/scratch.go
+++ b/pkg/cmd/tasks/initcmd/scratch.go
@@ -56,8 +56,11 @@ func initFromScratch(ctx context.Context, cfg config) error {
 	var scaffolder scaffolders.RuntimeScaffolder
 	if runtime == runtimeKindManual {
 		// TODO: let folks enter an image
-		def.Image = "alpine:3"
-		def.Command = []string{"echo", `"Hello World"`}
+		manual := definitions.ManualDefinition{
+			Image:   "alpine:3",
+			Command: []string{"echo", `"Hello World"`},
+		}
+		def.Manual = &manual
 	} else {
 		if scaffolder, err = defaultRuntimeConfig(runtime, &def); err != nil {
 			return err

--- a/pkg/cmd/tasks/initcmd/scratch.go
+++ b/pkg/cmd/tasks/initcmd/scratch.go
@@ -10,6 +10,7 @@ import (
 	"github.com/airplanedev/cli/pkg/cmd/tasks/initcmd/scaffolders"
 	"github.com/airplanedev/cli/pkg/logger"
 	"github.com/airplanedev/cli/pkg/taskdir"
+	"github.com/airplanedev/cli/pkg/taskdir/definitions"
 	"github.com/pkg/errors"
 )
 
@@ -47,7 +48,7 @@ func initFromScratch(ctx context.Context, cfg config) error {
 		return errors.Wrap(err, "getting unique slug")
 	}
 
-	def := taskdir.Definition{
+	def := definitions.Definition{
 		Slug:        r.Slug,
 		Name:        name,
 		Description: description,
@@ -164,7 +165,7 @@ func pickString(msg string, opts ...survey.AskOpt) (string, error) {
 
 // For the various runtimes, we pre-populate basic versions of e.g. package.json to reduce how much
 // the user has to set up.
-func writeRuntimeFiles(def taskdir.Definition, scaffolder scaffolders.RuntimeScaffolder) error {
+func writeRuntimeFiles(def definitions.Definition, scaffolder scaffolders.RuntimeScaffolder) error {
 	files := map[string][]byte{}
 	if err := scaffolder.GenerateFiles(def, files); err != nil {
 		return err

--- a/pkg/cmd/tasks/initcmd/scratch.go
+++ b/pkg/cmd/tasks/initcmd/scratch.go
@@ -91,7 +91,7 @@ func defaultRuntimeConfig(runtime runtimeKind, def *definitions.Definition) (sca
 		def.Deno.Entrypoint = "main.ts"
 		return scaffolders.DenoScaffolder{Entrypoint: "main.ts"}, nil
 	case runtimeKindDockerfile:
-		def.Docker.Dockerfile = "Dockerfile"
+		def.Dockerfile.Dockerfile = "Dockerfile"
 		return scaffolders.DockerfileScaffolder{Dockerfile: "Dockerfile"}, nil
 	case runtimeKindGo:
 		def.Go.Entrypoint = "main.go"

--- a/pkg/cmd/tasks/initcmd/task.go
+++ b/pkg/cmd/tasks/initcmd/task.go
@@ -53,11 +53,11 @@ func initFromTask(ctx context.Context, cfg config) error {
 		Constraints:    task.Constraints,
 		Env:            task.Env,
 		ResourceLimits: task.ResourceLimits,
-		Kind:           task.Kind,
-		KindOptions:    task.KindOptions,
 		Repo:           task.Repo,
 		Timeout:        task.Timeout,
 	}
+	def.FromKindAndOptions(task.Kind, task.KindOptions)
+
 	// Only show the image field if this is a manual builder
 	if task.Kind == "manual" {
 		def.Image = task.Image

--- a/pkg/cmd/tasks/initcmd/task.go
+++ b/pkg/cmd/tasks/initcmd/task.go
@@ -9,6 +9,7 @@ import (
 	"github.com/airplanedev/cli/pkg/api"
 	"github.com/airplanedev/cli/pkg/logger"
 	"github.com/airplanedev/cli/pkg/taskdir"
+	"github.com/airplanedev/cli/pkg/taskdir/definitions"
 	"github.com/pkg/errors"
 )
 
@@ -42,7 +43,7 @@ func initFromTask(ctx context.Context, cfg config) error {
 		return errors.Wrap(err, "getting unique slug")
 	}
 
-	def := taskdir.Definition{
+	def := definitions.Definition{
 		Slug:           r.Slug,
 		Name:           task.Name,
 		Description:    task.Description,

--- a/pkg/cmd/tasks/initcmd/task.go
+++ b/pkg/cmd/tasks/initcmd/task.go
@@ -43,25 +43,13 @@ func initFromTask(ctx context.Context, cfg config) error {
 		return errors.Wrap(err, "getting unique slug")
 	}
 
-	def := definitions.Definition{
-		Slug:           r.Slug,
-		Name:           task.Name,
-		Description:    task.Description,
-		Command:        task.Command,
-		Arguments:      task.Arguments,
-		Parameters:     task.Parameters,
-		Constraints:    task.Constraints,
-		Env:            task.Env,
-		ResourceLimits: task.ResourceLimits,
-		Repo:           task.Repo,
-		Timeout:        task.Timeout,
+	def, err := definitions.NewDefinitionFromTask(task)
+	if err != nil {
+		return err
 	}
-	def.FromKindAndOptions(task.Kind, task.KindOptions)
 
-	// Only show the image field if this is a manual builder
-	if task.Kind == "manual" {
-		def.Image = task.Image
-	}
+	def.Slug = r.Slug
+
 	if err := dir.WriteDefinition(def); err != nil {
 		return errors.Wrap(err, "writing task definition")
 	}

--- a/pkg/cmd/tasks/initcmd/task.go
+++ b/pkg/cmd/tasks/initcmd/task.go
@@ -52,8 +52,8 @@ func initFromTask(ctx context.Context, cfg config) error {
 		Constraints:    task.Constraints,
 		Env:            task.Env,
 		ResourceLimits: task.ResourceLimits,
-		Builder:        task.Kind,
-		BuilderConfig:  task.KindOptions,
+		Kind:           task.Kind,
+		KindOptions:    task.KindOptions,
 		Repo:           task.Repo,
 		Timeout:        task.Timeout,
 	}

--- a/pkg/print/types.go
+++ b/pkg/print/types.go
@@ -6,21 +6,21 @@ import (
 
 // This struct mirrors api.Task, but with different json/yaml tags.
 type printTask struct {
-	ID             string             `json:"taskID" yaml:"id"`
-	Name           string             `json:"name" yaml:"name"`
-	Slug           string             `json:"slug" yaml:"slug"`
-	Description    string             `json:"description" yaml:"description"`
-	Image          string             `json:"image" yaml:"image"`
-	Command        []string           `json:"command" yaml:"command"`
-	Arguments      []string           `json:"arguments" yaml:"arguments"`
-	Parameters     api.Parameters     `json:"parameters" yaml:"parameters"`
-	Constraints    api.RunConstraints `json:"constraints" yaml:"constraints"`
-	Env            api.TaskEnv        `json:"env" yaml:"env"`
-	ResourceLimits api.ResourceLimits `json:"resourceLimits" yaml:"resourceLimits"`
-	Kind           string             `json:"builder" yaml:"builder"`
-	KindOptions    api.KindOptions    `json:"builderConfig" yaml:"builderConfig"`
-	Repo           string             `json:"repo" yaml:"repo"`
-	Timeout        int                `json:"timeout" yaml:"timeout"`
+	ID               string               `json:"taskID" yaml:"id"`
+	Name             string               `json:"name" yaml:"name"`
+	Slug             string               `json:"slug" yaml:"slug"`
+	Description      string               `json:"description" yaml:"description"`
+	Image            string               `json:"image" yaml:"image"`
+	Command          []string             `json:"command" yaml:"command"`
+	Arguments        []string             `json:"arguments" yaml:"arguments"`
+	Parameters       api.Parameters       `json:"parameters" yaml:"parameters"`
+	Constraints      api.RunConstraints   `json:"constraints" yaml:"constraints"`
+	Env              api.TaskEnv          `json:"env" yaml:"env"`
+	ResourceRequests api.ResourceRequests `json:"resourceRequests" yaml:"resourceRequests"`
+	Kind             string               `json:"builder" yaml:"builder"`
+	KindOptions      api.KindOptions      `json:"builderConfig" yaml:"builderConfig"`
+	Repo             string               `json:"repo" yaml:"repo"`
+	Timeout          int                  `json:"timeout" yaml:"timeout"`
 }
 
 func printTasks(tasks []api.Task) []printTask {

--- a/pkg/taskdir/definitions.go
+++ b/pkg/taskdir/definitions.go
@@ -1,0 +1,95 @@
+package taskdir
+
+import (
+	"github.com/airplanedev/cli/pkg/api"
+	"github.com/pkg/errors"
+)
+
+// Definition represents a YAML-based task definition that can be used to create
+// or update Airplane tasks.
+//
+// Note this is the subset of fields that can be represented with a revision,
+// and therefore isolated to a specific environment.
+type Definition Definition_0_2
+
+func (this Definition) Validate() (Definition, error) {
+	if this.Slug == "" {
+		return this, errors.New("Expected a task slug")
+	}
+
+	// TODO: validate the rest of the fields!
+
+	return this, nil
+}
+
+type Definition_0_2 struct {
+	Slug           string             `yaml:"slug"`
+	Name           string             `yaml:"name"`
+	Description    string             `yaml:"description,omitempty"`
+	Image          string             `yaml:"image,omitempty"`
+	Command        []string           `yaml:"command,omitempty"`
+	Arguments      []string           `yaml:"arguments,omitempty"`
+	Parameters     api.Parameters     `yaml:"parameters,omitempty"`
+	Constraints    api.RunConstraints `yaml:"constraints,omitempty"`
+	Env            api.TaskEnv        `yaml:"env,omitempty"`
+	ResourceLimits api.ResourceLimits `yaml:"resourceLimits,omitempty"`
+	Kind           string             `yaml:"kind,omitempty"`
+	KindOptions    api.KindOptions    `yaml:"kindOptions,omitempty"`
+	Repo           string             `yaml:"repo,omitempty"`
+	Timeout        int                `yaml:"timeout,omitempty"`
+
+	// Root is a directory path relative to the parent directory of this
+	// task definition which defines what directory should be included
+	// in the task's Docker image.
+	//
+	// If not set, defaults to "." (in other words, the parent directory of this task definition).
+	//
+	// This field is ignored when using the pre-built image builder (aka "manual").
+	Root string `yaml:"root,omitempty"`
+}
+
+type Definition_0_1 struct {
+	Slug           string             `yaml:"slug"`
+	Name           string             `yaml:"name"`
+	Description    string             `yaml:"description,omitempty"`
+	Image          string             `yaml:"image,omitempty"`
+	Command        []string           `yaml:"command,omitempty"`
+	Arguments      []string           `yaml:"arguments,omitempty"`
+	Parameters     api.Parameters     `yaml:"parameters,omitempty"`
+	Constraints    api.RunConstraints `yaml:"constraints,omitempty"`
+	Env            api.TaskEnv        `yaml:"env,omitempty"`
+	ResourceLimits api.ResourceLimits `yaml:"resourceLimits,omitempty"`
+	Builder        string             `yaml:"builder,omitempty"`
+	BuilderConfig  api.KindOptions    `yaml:"builderConfig,omitempty"`
+	Repo           string             `yaml:"repo,omitempty"`
+	Timeout        int                `yaml:"timeout,omitempty"`
+
+	// Root is a directory path relative to the parent directory of this
+	// task definition which defines what directory should be included
+	// in the task's Docker image.
+	//
+	// If not set, defaults to "." (in other words, the parent directory of this task definition).
+	//
+	// This field is ignored when using the pre-built image builder (aka "manual").
+	Root string `yaml:"root,omitempty"`
+}
+
+func (d Definition_0_1) upgrade() (Definition, error) {
+	return Definition{
+		Slug:           d.Slug,
+		Name:           d.Name,
+		Description:    d.Description,
+		Image:          d.Image,
+		Command:        d.Command,
+		Arguments:      d.Arguments,
+		Parameters:     d.Parameters,
+		Constraints:    d.Constraints,
+		Env:            d.Env,
+		ResourceLimits: d.ResourceLimits,
+		Kind:           d.Builder,
+		KindOptions:    d.BuilderConfig,
+		Repo:           d.Repo,
+		Timeout:        d.Timeout,
+		Root:           d.Root,
+	}, nil
+}

--- a/pkg/taskdir/definitions/def_0_1.go
+++ b/pkg/taskdir/definitions/def_0_1.go
@@ -54,7 +54,7 @@ func (d Definition_0_1) upgrade() (Definition, error) {
 		docker := DockerDefinition{
 			Dockerfile: d.BuilderConfig["dockerfile"],
 		}
-		def.Docker = &docker
+		def.Dockerfile = &docker
 
 	} else if d.Builder == "go" {
 		godef := GoDefinition{

--- a/pkg/taskdir/definitions/def_0_1.go
+++ b/pkg/taskdir/definitions/def_0_1.go
@@ -31,7 +31,7 @@ type Definition_0_1 struct {
 }
 
 func (d Definition_0_1) upgrade() (Definition, error) {
-	return Definition_0_2{
+	def := Definition_0_2{
 		Slug:           d.Slug,
 		Name:           d.Name,
 		Description:    d.Description,
@@ -42,10 +42,49 @@ func (d Definition_0_1) upgrade() (Definition, error) {
 		Constraints:    d.Constraints,
 		Env:            d.Env,
 		ResourceLimits: d.ResourceLimits,
-		Kind:           d.Builder,
-		KindOptions:    d.BuilderConfig,
 		Repo:           d.Repo,
 		Timeout:        d.Timeout,
 		Root:           d.Root,
-	}.upgrade()
+	}
+
+	if d.Builder == "deno" {
+		deno := DenoDefinition{
+			Entrypoint: d.BuilderConfig["entrypoint"],
+		}
+		def.Deno = &deno
+
+	} else if d.Builder == "docker" {
+		docker := DockerDefinition{
+			Dockerfile: d.BuilderConfig["dockerfile"],
+		}
+		def.Docker = &docker
+
+	} else if d.Builder == "go" {
+		godef := GoDefinition{
+			Entrypoint: d.BuilderConfig["entrypoint"],
+		}
+		def.Go = &godef
+
+	} else if d.Builder == "node" {
+		node := NodeDefinition{
+			Entrypoint:  d.BuilderConfig["entrypoint"],
+			Language:    d.BuilderConfig["language"],
+			NodeVersion: d.BuilderConfig["nodeVersion"],
+		}
+		def.Node = &node
+
+	} else if d.Builder == "python" {
+		python := PythonDefinition{
+			Entrypoint: d.BuilderConfig["entrypoint"],
+		}
+		def.Python = &python
+
+	} else if d.Builder == "" {
+		manual := ManualDefinition{
+			Config: d.BuilderConfig,
+		}
+		def.Manual = &manual
+	}
+
+	return def.upgrade()
 }

--- a/pkg/taskdir/definitions/def_0_1.go
+++ b/pkg/taskdir/definitions/def_0_1.go
@@ -1,52 +1,8 @@
-package taskdir
+package definitions
 
 import (
 	"github.com/airplanedev/cli/pkg/api"
-	"github.com/pkg/errors"
 )
-
-// Definition represents a YAML-based task definition that can be used to create
-// or update Airplane tasks.
-//
-// Note this is the subset of fields that can be represented with a revision,
-// and therefore isolated to a specific environment.
-type Definition Definition_0_2
-
-func (this Definition) Validate() (Definition, error) {
-	if this.Slug == "" {
-		return this, errors.New("Expected a task slug")
-	}
-
-	// TODO: validate the rest of the fields!
-
-	return this, nil
-}
-
-type Definition_0_2 struct {
-	Slug           string             `yaml:"slug"`
-	Name           string             `yaml:"name"`
-	Description    string             `yaml:"description,omitempty"`
-	Image          string             `yaml:"image,omitempty"`
-	Command        []string           `yaml:"command,omitempty"`
-	Arguments      []string           `yaml:"arguments,omitempty"`
-	Parameters     api.Parameters     `yaml:"parameters,omitempty"`
-	Constraints    api.RunConstraints `yaml:"constraints,omitempty"`
-	Env            api.TaskEnv        `yaml:"env,omitempty"`
-	ResourceLimits api.ResourceLimits `yaml:"resourceLimits,omitempty"`
-	Kind           string             `yaml:"kind,omitempty"`
-	KindOptions    api.KindOptions    `yaml:"kindOptions,omitempty"`
-	Repo           string             `yaml:"repo,omitempty"`
-	Timeout        int                `yaml:"timeout,omitempty"`
-
-	// Root is a directory path relative to the parent directory of this
-	// task definition which defines what directory should be included
-	// in the task's Docker image.
-	//
-	// If not set, defaults to "." (in other words, the parent directory of this task definition).
-	//
-	// This field is ignored when using the pre-built image builder (aka "manual").
-	Root string `yaml:"root,omitempty"`
-}
 
 type Definition_0_1 struct {
 	Slug           string             `yaml:"slug"`
@@ -75,7 +31,7 @@ type Definition_0_1 struct {
 }
 
 func (d Definition_0_1) upgrade() (Definition, error) {
-	return Definition{
+	return Definition_0_2{
 		Slug:           d.Slug,
 		Name:           d.Name,
 		Description:    d.Description,
@@ -91,5 +47,5 @@ func (d Definition_0_1) upgrade() (Definition, error) {
 		Repo:           d.Repo,
 		Timeout:        d.Timeout,
 		Root:           d.Root,
-	}, nil
+	}.upgrade()
 }

--- a/pkg/taskdir/definitions/def_0_1.go
+++ b/pkg/taskdir/definitions/def_0_1.go
@@ -35,8 +35,6 @@ func (d Definition_0_1) upgrade() (Definition, error) {
 		Slug:           d.Slug,
 		Name:           d.Name,
 		Description:    d.Description,
-		Image:          d.Image,
-		Command:        d.Command,
 		Arguments:      d.Arguments,
 		Parameters:     d.Parameters,
 		Constraints:    d.Constraints,
@@ -81,7 +79,8 @@ func (d Definition_0_1) upgrade() (Definition, error) {
 
 	} else if d.Builder == "" {
 		manual := ManualDefinition{
-			Config: d.BuilderConfig,
+			Image:   d.Image,
+			Command: d.Command,
 		}
 		def.Manual = &manual
 	}

--- a/pkg/taskdir/definitions/def_0_1.go
+++ b/pkg/taskdir/definitions/def_0_1.go
@@ -14,7 +14,7 @@ type Definition_0_1 struct {
 	Parameters     api.Parameters     `yaml:"parameters,omitempty"`
 	Constraints    api.RunConstraints `yaml:"constraints,omitempty"`
 	Env            api.TaskEnv        `yaml:"env,omitempty"`
-	ResourceLimits api.ResourceLimits `yaml:"resourceLimits,omitempty"`
+	ResourceLimits map[string]string  `yaml:"resourceLimits,omitempty"`
 	Builder        string             `yaml:"builder,omitempty"`
 	BuilderConfig  api.KindOptions    `yaml:"builderConfig,omitempty"`
 	Repo           string             `yaml:"repo,omitempty"`
@@ -32,17 +32,16 @@ type Definition_0_1 struct {
 
 func (d Definition_0_1) upgrade() (Definition, error) {
 	def := Definition_0_2{
-		Slug:           d.Slug,
-		Name:           d.Name,
-		Description:    d.Description,
-		Arguments:      d.Arguments,
-		Parameters:     d.Parameters,
-		Constraints:    d.Constraints,
-		Env:            d.Env,
-		ResourceLimits: d.ResourceLimits,
-		Repo:           d.Repo,
-		Timeout:        d.Timeout,
-		Root:           d.Root,
+		Slug:        d.Slug,
+		Name:        d.Name,
+		Description: d.Description,
+		Arguments:   d.Arguments,
+		Parameters:  d.Parameters,
+		Constraints: d.Constraints,
+		Env:         d.Env,
+		Repo:        d.Repo,
+		Timeout:     d.Timeout,
+		Root:        d.Root,
 	}
 
 	if d.Builder == "deno" {

--- a/pkg/taskdir/definitions/def_0_2.go
+++ b/pkg/taskdir/definitions/def_0_2.go
@@ -8,8 +8,6 @@ type Definition_0_2 struct {
 	Slug           string             `yaml:"slug"`
 	Name           string             `yaml:"name"`
 	Description    string             `yaml:"description,omitempty"`
-	Image          string             `yaml:"image,omitempty"`
-	Command        []string           `yaml:"command,omitempty"`
 	Arguments      []string           `yaml:"arguments,omitempty"`
 	Parameters     api.Parameters     `yaml:"parameters,omitempty"`
 	Constraints    api.RunConstraints `yaml:"constraints,omitempty"`
@@ -36,7 +34,8 @@ type Definition_0_2 struct {
 }
 
 type ManualDefinition struct {
-	Config map[string]string
+	Image   string   `yaml:"image,omitempty"`
+	Command []string `yaml:"command,omitempty"`
 }
 
 type DenoDefinition struct {

--- a/pkg/taskdir/definitions/def_0_2.go
+++ b/pkg/taskdir/definitions/def_0_2.go
@@ -15,10 +15,15 @@ type Definition_0_2 struct {
 	Constraints    api.RunConstraints `yaml:"constraints,omitempty"`
 	Env            api.TaskEnv        `yaml:"env,omitempty"`
 	ResourceLimits api.ResourceLimits `yaml:"resourceLimits,omitempty"`
-	Kind           string             `yaml:"kind,omitempty"`
-	KindOptions    api.KindOptions    `yaml:"kindOptions,omitempty"`
 	Repo           string             `yaml:"repo,omitempty"`
 	Timeout        int                `yaml:"timeout,omitempty"`
+
+	Manual *ManualDefinition `yaml:"manual,omitempty"`
+	Deno   *DenoDefinition   `yaml:"deno,omitempty"`
+	Docker *DockerDefinition `yaml:"docker,omitempty"`
+	Go     *GoDefinition     `yaml:"go,omitempty"`
+	Node   *NodeDefinition   `yaml:"node,omitempty"`
+	Python *PythonDefinition `yaml:"python,omitempty"`
 
 	// Root is a directory path relative to the parent directory of this
 	// task definition which defines what directory should be included
@@ -28,6 +33,32 @@ type Definition_0_2 struct {
 	//
 	// This field is ignored when using the pre-built image builder (aka "manual").
 	Root string `yaml:"root,omitempty"`
+}
+
+type ManualDefinition struct {
+	Config map[string]string
+}
+
+type DenoDefinition struct {
+	Entrypoint string `yaml:"entrypoint"`
+}
+
+type DockerDefinition struct {
+	Dockerfile string `yaml:"dockerfile"`
+}
+
+type GoDefinition struct {
+	Entrypoint string `yaml:"entrypoint"`
+}
+
+type NodeDefinition struct {
+	Entrypoint  string `yaml:"entrypoint"`
+	Language    string `yaml:"language"`
+	NodeVersion string `yaml:"nodeVersion"`
+}
+
+type PythonDefinition struct {
+	Entrypoint string `yaml:"entrypoint"`
 }
 
 func (d Definition_0_2) upgrade() (Definition, error) {

--- a/pkg/taskdir/definitions/def_0_2.go
+++ b/pkg/taskdir/definitions/def_0_2.go
@@ -5,16 +5,16 @@ import (
 )
 
 type Definition_0_2 struct {
-	Slug           string             `yaml:"slug"`
-	Name           string             `yaml:"name"`
-	Description    string             `yaml:"description,omitempty"`
-	Arguments      []string           `yaml:"arguments,omitempty"`
-	Parameters     api.Parameters     `yaml:"parameters,omitempty"`
-	Constraints    api.RunConstraints `yaml:"constraints,omitempty"`
-	Env            api.TaskEnv        `yaml:"env,omitempty"`
-	ResourceLimits api.ResourceLimits `yaml:"resourceLimits,omitempty"`
-	Repo           string             `yaml:"repo,omitempty"`
-	Timeout        int                `yaml:"timeout,omitempty"`
+	Slug             string               `yaml:"slug"`
+	Name             string               `yaml:"name"`
+	Description      string               `yaml:"description,omitempty"`
+	Arguments        []string             `yaml:"arguments,omitempty"`
+	Parameters       api.Parameters       `yaml:"parameters,omitempty"`
+	Constraints      api.RunConstraints   `yaml:"constraints,omitempty"`
+	Env              api.TaskEnv          `yaml:"env,omitempty"`
+	ResourceRequests api.ResourceRequests `yaml:"resourceRequests,omitempty"`
+	Repo             string               `yaml:"repo,omitempty"`
+	Timeout          int                  `yaml:"timeout,omitempty"`
 
 	Manual *ManualDefinition `yaml:"manual,omitempty"`
 	Deno   *DenoDefinition   `yaml:"deno,omitempty"`

--- a/pkg/taskdir/definitions/def_0_2.go
+++ b/pkg/taskdir/definitions/def_0_2.go
@@ -16,12 +16,12 @@ type Definition_0_2 struct {
 	Repo             string               `yaml:"repo,omitempty"`
 	Timeout          int                  `yaml:"timeout,omitempty"`
 
-	Manual *ManualDefinition `yaml:"manual,omitempty"`
-	Deno   *DenoDefinition   `yaml:"deno,omitempty"`
-	Docker *DockerDefinition `yaml:"docker,omitempty"`
-	Go     *GoDefinition     `yaml:"go,omitempty"`
-	Node   *NodeDefinition   `yaml:"node,omitempty"`
-	Python *PythonDefinition `yaml:"python,omitempty"`
+	Manual     *ManualDefinition `yaml:"manual,omitempty"`
+	Deno       *DenoDefinition   `yaml:"deno,omitempty"`
+	Dockerfile *DockerDefinition `yaml:"dockerfile,omitempty"`
+	Go         *GoDefinition     `yaml:"go,omitempty"`
+	Node       *NodeDefinition   `yaml:"node,omitempty"`
+	Python     *PythonDefinition `yaml:"python,omitempty"`
 
 	// Root is a directory path relative to the parent directory of this
 	// task definition which defines what directory should be included

--- a/pkg/taskdir/definitions/def_0_2.go
+++ b/pkg/taskdir/definitions/def_0_2.go
@@ -1,0 +1,35 @@
+package definitions
+
+import (
+	"github.com/airplanedev/cli/pkg/api"
+)
+
+type Definition_0_2 struct {
+	Slug           string             `yaml:"slug"`
+	Name           string             `yaml:"name"`
+	Description    string             `yaml:"description,omitempty"`
+	Image          string             `yaml:"image,omitempty"`
+	Command        []string           `yaml:"command,omitempty"`
+	Arguments      []string           `yaml:"arguments,omitempty"`
+	Parameters     api.Parameters     `yaml:"parameters,omitempty"`
+	Constraints    api.RunConstraints `yaml:"constraints,omitempty"`
+	Env            api.TaskEnv        `yaml:"env,omitempty"`
+	ResourceLimits api.ResourceLimits `yaml:"resourceLimits,omitempty"`
+	Kind           string             `yaml:"kind,omitempty"`
+	KindOptions    api.KindOptions    `yaml:"kindOptions,omitempty"`
+	Repo           string             `yaml:"repo,omitempty"`
+	Timeout        int                `yaml:"timeout,omitempty"`
+
+	// Root is a directory path relative to the parent directory of this
+	// task definition which defines what directory should be included
+	// in the task's Docker image.
+	//
+	// If not set, defaults to "." (in other words, the parent directory of this task definition).
+	//
+	// This field is ignored when using the pre-built image builder (aka "manual").
+	Root string `yaml:"root,omitempty"`
+}
+
+func (d Definition_0_2) upgrade() (Definition, error) {
+	return Definition(d), nil
+}

--- a/pkg/taskdir/definitions/definitions.go
+++ b/pkg/taskdir/definitions/definitions.go
@@ -39,7 +39,7 @@ func NewDefinitionFromTask(task api.Task) (Definition, error) {
 		docker := DockerDefinition{
 			Dockerfile: task.KindOptions["dockerfile"],
 		}
-		def.Docker = &docker
+		def.Dockerfile = &docker
 
 	} else if task.Kind == "go" {
 		godef := GoDefinition{
@@ -80,9 +80,9 @@ func (this Definition) GetKindAndOptions() (string, api.KindOptions, error) {
 		return "deno", api.KindOptions{
 			"entrypoint": this.Deno.Entrypoint,
 		}, nil
-	} else if this.Docker != nil {
+	} else if this.Dockerfile != nil {
 		return "docker", api.KindOptions{
-			"dockerfile": this.Docker.Dockerfile,
+			"dockerfile": this.Dockerfile.Dockerfile,
 		}, nil
 	} else if this.Go != nil {
 		return "go", api.KindOptions{

--- a/pkg/taskdir/definitions/definitions.go
+++ b/pkg/taskdir/definitions/definitions.go
@@ -3,6 +3,7 @@ package definitions
 import (
 	"fmt"
 
+	"github.com/airplanedev/cli/pkg/api"
 	"github.com/pkg/errors"
 	"gopkg.in/yaml.v3"
 )
@@ -13,6 +14,82 @@ import (
 // Note this is the subset of fields that can be represented with a revision,
 // and therefore isolated to a specific environment.
 type Definition Definition_0_2
+
+func (this Definition) FromKindAndOptions(kind string, options api.KindOptions) error {
+	if kind == "deno" {
+		deno := DenoDefinition{
+			Entrypoint: options["entrypoint"],
+		}
+		this.Deno = &deno
+
+	} else if kind == "docker" {
+		docker := DockerDefinition{
+			Dockerfile: options["dockerfile"],
+		}
+		this.Docker = &docker
+
+	} else if kind == "go" {
+		godef := GoDefinition{
+			Entrypoint: options["entrypoint"],
+		}
+		this.Go = &godef
+
+	} else if kind == "node" {
+		node := NodeDefinition{
+			Entrypoint:  options["entrypoint"],
+			Language:    options["language"],
+			NodeVersion: options["nodeVersion"],
+		}
+		this.Node = &node
+
+	} else if kind == "python" {
+		python := PythonDefinition{
+			Entrypoint: options["entrypoint"],
+		}
+		this.Python = &python
+
+	} else if kind == "" {
+		manual := ManualDefinition{
+			Config: options,
+		}
+		this.Manual = &manual
+
+	} else {
+		return errors.Errorf("unknown kind specified: %s", kind)
+	}
+
+	return nil
+}
+
+func (this Definition) GetKindAndOptions() (string, api.KindOptions, error) {
+	if this.Deno != nil {
+		return "deno", api.KindOptions{
+			"entrypoint": this.Deno.Entrypoint,
+		}, nil
+	} else if this.Docker != nil {
+		return "docker", api.KindOptions{
+			"dockerfile": this.Docker.Dockerfile,
+		}, nil
+	} else if this.Go != nil {
+		return "go", api.KindOptions{
+			"entrypoint": this.Go.Entrypoint,
+		}, nil
+	} else if this.Node != nil {
+		return "node", api.KindOptions{
+			"entrypoint":  this.Node.Entrypoint,
+			"language":    this.Node.Language,
+			"nodeVersion": this.Node.NodeVersion,
+		}, nil
+	} else if this.Python != nil {
+		return "python", api.KindOptions{
+			"entrypoint": this.Python.Entrypoint,
+		}, nil
+	} else if this.Manual != nil {
+		return "", api.KindOptions(this.Manual.Config), nil
+	}
+
+	return "", api.KindOptions{}, errors.New("No kind specified")
+}
 
 func (this Definition) Validate() (Definition, error) {
 	if this.Slug == "" {

--- a/pkg/taskdir/definitions/definitions.go
+++ b/pkg/taskdir/definitions/definitions.go
@@ -15,50 +15,64 @@ import (
 // and therefore isolated to a specific environment.
 type Definition Definition_0_2
 
-func (this Definition) FromKindAndOptions(kind string, options api.KindOptions) error {
-	if kind == "deno" {
-		deno := DenoDefinition{
-			Entrypoint: options["entrypoint"],
-		}
-		this.Deno = &deno
-
-	} else if kind == "docker" {
-		docker := DockerDefinition{
-			Dockerfile: options["dockerfile"],
-		}
-		this.Docker = &docker
-
-	} else if kind == "go" {
-		godef := GoDefinition{
-			Entrypoint: options["entrypoint"],
-		}
-		this.Go = &godef
-
-	} else if kind == "node" {
-		node := NodeDefinition{
-			Entrypoint:  options["entrypoint"],
-			Language:    options["language"],
-			NodeVersion: options["nodeVersion"],
-		}
-		this.Node = &node
-
-	} else if kind == "python" {
-		python := PythonDefinition{
-			Entrypoint: options["entrypoint"],
-		}
-		this.Python = &python
-
-	} else if kind == "" {
-		manual := ManualDefinition{
-			Config: options,
-		}
-		this.Manual = &manual
-
-	} else {
-		return errors.Errorf("unknown kind specified: %s", kind)
+func NewDefinitionFromTask(task api.Task) (Definition, error) {
+	def := Definition{
+		Slug:           task.Slug,
+		Name:           task.Name,
+		Description:    task.Description,
+		Arguments:      task.Arguments,
+		Parameters:     task.Parameters,
+		Constraints:    task.Constraints,
+		Env:            task.Env,
+		ResourceLimits: task.ResourceLimits,
+		Repo:           task.Repo,
+		Timeout:        task.Timeout,
 	}
 
-	return nil
+	if task.Kind == "deno" {
+		deno := DenoDefinition{
+			Entrypoint: task.KindOptions["entrypoint"],
+		}
+		def.Deno = &deno
+
+	} else if task.Kind == "docker" {
+		docker := DockerDefinition{
+			Dockerfile: task.KindOptions["dockerfile"],
+		}
+		def.Docker = &docker
+
+	} else if task.Kind == "go" {
+		godef := GoDefinition{
+			Entrypoint: task.KindOptions["entrypoint"],
+		}
+		def.Go = &godef
+
+	} else if task.Kind == "node" {
+		node := NodeDefinition{
+			Entrypoint:  task.KindOptions["entrypoint"],
+			Language:    task.KindOptions["language"],
+			NodeVersion: task.KindOptions["nodeVersion"],
+		}
+		def.Node = &node
+
+	} else if task.Kind == "python" {
+		python := PythonDefinition{
+			Entrypoint: task.KindOptions["entrypoint"],
+		}
+		def.Python = &python
+
+	} else if task.Kind == "" {
+		manual := ManualDefinition{
+			Image:   task.Image,
+			Command: task.Command,
+		}
+		def.Manual = &manual
+
+	} else {
+		return Definition{}, errors.Errorf("unknown kind specified: %s", task.Kind)
+	}
+
+	return def, nil
 }
 
 func (this Definition) GetKindAndOptions() (string, api.KindOptions, error) {
@@ -85,7 +99,7 @@ func (this Definition) GetKindAndOptions() (string, api.KindOptions, error) {
 			"entrypoint": this.Python.Entrypoint,
 		}, nil
 	} else if this.Manual != nil {
-		return "", api.KindOptions(this.Manual.Config), nil
+		return "", api.KindOptions{}, nil
 	}
 
 	return "", api.KindOptions{}, errors.New("No kind specified")

--- a/pkg/taskdir/definitions/definitions.go
+++ b/pkg/taskdir/definitions/definitions.go
@@ -17,16 +17,16 @@ type Definition Definition_0_2
 
 func NewDefinitionFromTask(task api.Task) (Definition, error) {
 	def := Definition{
-		Slug:           task.Slug,
-		Name:           task.Name,
-		Description:    task.Description,
-		Arguments:      task.Arguments,
-		Parameters:     task.Parameters,
-		Constraints:    task.Constraints,
-		Env:            task.Env,
-		ResourceLimits: task.ResourceLimits,
-		Repo:           task.Repo,
-		Timeout:        task.Timeout,
+		Slug:             task.Slug,
+		Name:             task.Name,
+		Description:      task.Description,
+		Arguments:        task.Arguments,
+		Parameters:       task.Parameters,
+		Constraints:      task.Constraints,
+		Env:              task.Env,
+		ResourceRequests: task.ResourceRequests,
+		Repo:             task.Repo,
+		Timeout:          task.Timeout,
 	}
 
 	if task.Kind == "deno" {

--- a/pkg/taskdir/definitions/definitions.go
+++ b/pkg/taskdir/definitions/definitions.go
@@ -1,0 +1,68 @@
+package definitions
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+	"gopkg.in/yaml.v3"
+)
+
+// Definition represents a YAML-based task definition that can be used to create
+// or update Airplane tasks.
+//
+// Note this is the subset of fields that can be represented with a revision,
+// and therefore isolated to a specific environment.
+type Definition Definition_0_2
+
+func (this Definition) Validate() (Definition, error) {
+	if this.Slug == "" {
+		return this, errors.New("Expected a task slug")
+	}
+
+	// TODO: validate the rest of the fields!
+
+	return this, nil
+}
+
+func UnmarshalDefinition(buf []byte, defPath string) (Definition, error) {
+	// Validate definition against our Definition struct
+	if err := validateYAML(buf, Definition{}); err != nil {
+		// Try older definitions?
+		if def, oerr := tryOlderDefinitions(buf); oerr == nil {
+			return def, nil
+		}
+
+		// Print any "expected" validation errors
+		switch err := errors.Cause(err).(type) {
+		case ErrInvalidYAML:
+			return Definition{}, newErrReadDefinition(fmt.Sprintf("Error reading %s: invalid YAML", defPath))
+		case ErrSchemaValidation:
+			errorMsgs := []string{}
+			for _, verr := range err.Errors {
+				errorMsgs = append(errorMsgs, fmt.Sprintf("%s: %s", verr.Field(), verr.Description()))
+			}
+			return Definition{}, newErrReadDefinition(fmt.Sprintf("Error reading %s", defPath), errorMsgs...)
+		default:
+			return Definition{}, errors.Wrapf(err, "reading %s", defPath)
+		}
+	}
+
+	var def Definition
+	if err := yaml.Unmarshal(buf, &def); err != nil {
+		return Definition{}, errors.Wrap(err, "unmarshalling task definition")
+	}
+
+	return def, nil
+}
+
+func tryOlderDefinitions(buf []byte) (Definition, error) {
+	var err error
+	if err = validateYAML(buf, Definition_0_1{}); err == nil {
+		var def Definition_0_1
+		if e := yaml.Unmarshal(buf, &def); e != nil {
+			return Definition{}, err
+		}
+		return def.upgrade()
+	}
+	return Definition{}, err
+}

--- a/pkg/taskdir/definitions/error.go
+++ b/pkg/taskdir/definitions/error.go
@@ -1,0 +1,37 @@
+package definitions
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+const taskDefDocURL = "https://docs.airplane.dev/reference/task-definition-reference"
+
+type errReadDefinition struct {
+	msg       string
+	errorMsgs []string
+}
+
+func newErrReadDefinition(msg string, errorMsgs ...string) error {
+	return errors.WithStack(errReadDefinition{
+		msg:       msg,
+		errorMsgs: errorMsgs,
+	})
+}
+
+func (this errReadDefinition) Error() string {
+	return this.msg
+}
+
+// Implements ErrorExplained
+func (this errReadDefinition) ExplainError() string {
+	msgs := []string{}
+	msgs = append(msgs, this.errorMsgs...)
+	if len(this.errorMsgs) > 0 {
+		msgs = append(msgs, "")
+	}
+	msgs = append(msgs, fmt.Sprintf("For more information on the task definition format, see the docs:\n%s", taskDefDocURL))
+	return strings.Join(msgs, "\n")
+}

--- a/pkg/taskdir/definitions/validate.go
+++ b/pkg/taskdir/definitions/validate.go
@@ -1,4 +1,4 @@
-package taskdir
+package definitions
 
 import (
 	"github.com/alecthomas/jsonschema"
@@ -23,7 +23,7 @@ func (this ErrSchemaValidation) Error() string {
 
 // ValidateYAML checks that YAML data matches the schema defined by schemaObj
 // Returns ErrInvalidYAML if not valid YAML and ErrSchemaValidation if YAML doesn't match schemaObj
-func ValidateYAML(data []byte, schemaObj interface{}) error {
+func validateYAML(data []byte, schemaObj interface{}) error {
 	var obj interface{}
 	if err := yaml.Unmarshal(data, &obj); err != nil {
 		return errors.WithStack(ErrInvalidYAML{})

--- a/pkg/taskdir/taskdef.go
+++ b/pkg/taskdir/taskdef.go
@@ -1,102 +1,34 @@
 package taskdir
 
 import (
-	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/airplanedev/cli/pkg/logger"
+	"github.com/airplanedev/cli/pkg/taskdir/definitions"
 	"github.com/airplanedev/cli/pkg/utils"
 	"github.com/pkg/errors"
 	"gopkg.in/yaml.v3"
 )
 
-const taskDefDocURL = "https://docs.airplane.dev/reference/task-definition-reference"
-
-type errReadDefinition struct {
-	msg       string
-	errorMsgs []string
-}
-
-func newErrReadDefinition(msg string, errorMsgs ...string) error {
-	return errors.WithStack(errReadDefinition{
-		msg:       msg,
-		errorMsgs: errorMsgs,
-	})
-}
-
-func (this errReadDefinition) Error() string {
-	return this.msg
-}
-
-// Implements ErrorExplained
-func (this errReadDefinition) ExplainError() string {
-	msgs := []string{}
-	msgs = append(msgs, this.errorMsgs...)
-	if len(this.errorMsgs) > 0 {
-		msgs = append(msgs, "")
-	}
-	msgs = append(msgs, fmt.Sprintf("For more information on the task definition format, see the docs:\n%s", taskDefDocURL))
-	return strings.Join(msgs, "\n")
-}
-
-func (this TaskDirectory) ReadDefinition() (Definition, error) {
+func (this TaskDirectory) ReadDefinition() (definitions.Definition, error) {
 	buf, err := ioutil.ReadFile(this.defPath)
 	if err != nil {
-		return Definition{}, errors.Wrap(err, "reading task definition")
+		return definitions.Definition{}, errors.Wrap(err, "reading task definition")
 	}
 
-	// Validate definition against our Definition struct
-	if err := ValidateYAML(buf, Definition{}); err != nil {
-		// Try older definitions?
-		if def, oerr := tryOlderDefinitions(buf); oerr == nil {
-			return def, nil
-		}
-
-		defPath := this.defPath
-		// Attempt to set a prettier defPath, best effort
-		if wd, err := os.Getwd(); err != nil {
-			logger.Debug("%s", err)
-		} else if path, err := filepath.Rel(wd, defPath); err != nil {
-			logger.Debug("%s", err)
-		} else {
-			defPath = path
-		}
-		// Print any "expected" validation errors
-		switch err := errors.Cause(err).(type) {
-		case ErrInvalidYAML:
-			return Definition{}, newErrReadDefinition(fmt.Sprintf("Error reading %s: invalid YAML", defPath))
-		case ErrSchemaValidation:
-			errorMsgs := []string{}
-			for _, verr := range err.Errors {
-				errorMsgs = append(errorMsgs, fmt.Sprintf("%s: %s", verr.Field(), verr.Description()))
-			}
-			return Definition{}, newErrReadDefinition(fmt.Sprintf("Error reading %s", defPath), errorMsgs...)
-		default:
-			return Definition{}, errors.Wrapf(err, "reading %s", defPath)
-		}
+	defPath := this.defPath
+	// Attempt to set a prettier defPath, best effort
+	if wd, err := os.Getwd(); err != nil {
+		logger.Debug("%s", err)
+	} else if path, err := filepath.Rel(wd, defPath); err != nil {
+		logger.Debug("%s", err)
+	} else {
+		defPath = path
 	}
 
-	var def Definition
-	if err := yaml.Unmarshal(buf, &def); err != nil {
-		return Definition{}, errors.Wrap(err, "unmarshalling task definition")
-	}
-
-	return def, nil
-}
-
-func tryOlderDefinitions(buf []byte) (Definition, error) {
-	var err error
-	if err = ValidateYAML(buf, Definition_0_1{}); err == nil {
-		var def Definition_0_1
-		if e := yaml.Unmarshal(buf, &def); e != nil {
-			return Definition{}, err
-		}
-		return def.upgrade()
-	}
-	return Definition{}, err
+	return definitions.UnmarshalDefinition(buf, defPath)
 }
 
 // WriteSlug updates the slug of a task definition and persists this to disk.
@@ -110,7 +42,7 @@ func (this TaskDirectory) WriteSlug(slug string) error {
 	return nil
 }
 
-func (this TaskDirectory) WriteDefinition(def Definition) error {
+func (this TaskDirectory) WriteDefinition(def definitions.Definition) error {
 	data, err := yaml.Marshal(def)
 	if err != nil {
 		return errors.Wrap(err, "marshalling definition")


### PR DESCRIPTION
Before:
```
builder: python
builderConfig:
  entrypoint: main.py
```

After:
```
python:
  entrypoint: main.py
```

This PR adds logic for understanding multiple yaml file versions; the latest version will be tried first, & then previous versions. Only errors from the newest version will be shown to the user. This doesn't change the output of `tasks get`; communications with the API server are not changing, either. When initializing from a sample, if the sample's task definition is an older version, the new task definition will be upgraded in the newest version.

Bonus: `ResourceLimits` -> `ResourceRequests`.