### PR TITLE
Fix err shadowing in main.go

### DIFF
--- a/cmd/airplane/main.go
+++ b/cmd/airplane/main.go
@@ -32,10 +32,10 @@ func main() {
 			logger.Debug("Error: %+v", err)
 		}
 		logger.Log("")
-		if err, ok := errors.Cause(err).(utils.ErrorExplained); ok {
-			logger.Log(logger.Red(err.Error()))
+		if exerr, ok := errors.Cause(err).(utils.ErrorExplained); ok {
+			logger.Log(logger.Red(exerr.Error()))
 			logger.Log("")
-			logger.Log(err.ExplainError())
+			logger.Log(exerr.ExplainError())
 		} else {
 			logger.Log(logger.Red("Error: %s", errors.Cause(err).Error()))
 		}


### PR DESCRIPTION
Name it `exerr` so that the `else` block can use the original `err`.
Without this, when `!ok` the new `err` was nil, breaking the `else`
branch.
