### PR TITLE
Fix schema validation bug requiring both config and value

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -202,8 +202,8 @@ type ListTasksResponse struct {
 type TaskEnv map[string]EnvVarValue
 
 type EnvVarValue struct {
-	Value  *string `json:"value" yaml:"value"`
-	Config *string `json:"config" yaml:"config"`
+	Value  *string `json:"value" yaml:"value,omitempty"`
+	Config *string `json:"config" yaml:"config,omitempty"`
 }
 
 var _ yaml.Unmarshaler = &EnvVarValue{}


### PR DESCRIPTION
Adds `omitempty` to `EnvVarValue` so that CLI validation doesn't
complain if you do something normal like `MY_VAR: {"config":
"my_config"}`

Note that this still prevents `MY_VAR: "some_string"` - we should
perhaps just not support that for now.
