### PR TITLE
Improve init prompts and output

### DIFF
--- a/pkg/cmd/tasks/initcmd/scratch.go
+++ b/pkg/cmd/tasks/initcmd/scratch.go
@@ -74,14 +74,14 @@ func initFromScratch(ctx context.Context, cfg config) error {
 		return err
 	}
 
-	fileNameStr := "  - " + strings.Join(fileNames, "\n  - ")
+	fileNames = append([]string{file}, fileNames...)
+	fileNameList := "  - " + strings.Join(fileNames, "\n  - ")
 	logger.Log(`
 A skeleton Airplane task definition for '%s' has been created, along with other starter files:
-  - %s
 %s
 
 Once you are ready, deploy it to Airplane with:
-  airplane deploy -f %s`, name, file, fileNameStr, file)
+  airplane deploy -f %s`, name, fileNameList, file)
 
 	return nil
 }

--- a/pkg/cmd/tasks/initcmd/scratch.go
+++ b/pkg/cmd/tasks/initcmd/scratch.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io/ioutil"
 	"os"
+	"strings"
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/airplanedev/cli/pkg/api"
@@ -21,12 +22,12 @@ func initFromScratch(ctx context.Context, cfg config) error {
 		return err
 	}
 
-	name, err := pickString("Pick a name:", survey.WithValidator(survey.Required))
+	name, err := pickString("Enter a name:", survey.WithValidator(survey.Required))
 	if err != nil {
 		return err
 	}
 
-	description, err := pickString("Pick a description:")
+	description, err := pickString("Enter a description (optional):")
 	if err != nil {
 		return err
 	}
@@ -68,15 +69,19 @@ func initFromScratch(ctx context.Context, cfg config) error {
 		return err
 	}
 
-	if err := writeRuntimeFiles(def, scaffolder); err != nil {
+	fileNames, err := writeRuntimeFiles(def, scaffolder)
+	if err != nil {
 		return err
 	}
 
+	fileNameStr := "  - " + strings.Join(fileNames, "\n  - ")
 	logger.Log(`
-A skeleton Airplane task definition for '%s' has been created in %s, along with other starter files!
+A skeleton Airplane task definition for '%s' has been created, along with other starter files:
+  - %s
+%s
 
 Once you are ready, deploy it to Airplane with:
-  airplane deploy -f %s`, name, file, file)
+  airplane deploy -f %s`, name, file, fileNameStr, file)
 
 	return nil
 }
@@ -164,16 +169,18 @@ func pickString(msg string, opts ...survey.AskOpt) (string, error) {
 
 // For the various runtimes, we pre-populate basic versions of e.g. package.json to reduce how much
 // the user has to set up.
-func writeRuntimeFiles(def taskdir.Definition, scaffolder scaffolders.RuntimeScaffolder) error {
+func writeRuntimeFiles(def taskdir.Definition, scaffolder scaffolders.RuntimeScaffolder) ([]string, error) {
+	fileNames := []string{}
 	files := map[string][]byte{}
 	if err := scaffolder.GenerateFiles(def, files); err != nil {
-		return err
+		return nil, err
 	}
 	for filePath, fileContents := range files {
 		logger.Debug("writing file %s", filePath)
 		if err := ioutil.WriteFile(filePath, fileContents, 0664); err != nil {
-			return errors.Wrapf(err, "writing %s", filePath)
+			return nil, errors.Wrapf(err, "writing %s", filePath)
 		}
+		fileNames = append(fileNames, filePath)
 	}
-	return nil
+	return fileNames, nil
 }


### PR DESCRIPTION
Rewords "pick" to "enter" and maybe it clear description is optional.

Prints out all the files that are created, so users aren't surprised and
know what to open / inspect.
