### PR TITLE
Change waiting for build message

### DIFF
--- a/pkg/build/remote.go
+++ b/pkg/build/remote.go
@@ -229,7 +229,7 @@ func uploadArchive(ctx context.Context, client *api.Client, archivePath string) 
 }
 
 func waitForBuild(ctx context.Context, client *api.Client, buildID string) error {
-	buildLog(logger.Gray("Waiting for build to be assigned..."))
+	buildLog(logger.Gray("Waiting for builder..."))
 
 	t := time.NewTicker(time.Second)
 


### PR DESCRIPTION
We don't need to surface the concept of assignments to the end-user, who won't be familiar with our arch.