### PR TITLE
Only allow one definition on a task

### DIFF
--- a/pkg/taskdir/definitions/definitions.go
+++ b/pkg/taskdir/definitions/definitions.go
@@ -135,7 +135,7 @@ func (this Definition) Validate() (Definition, error) {
 		return this, errors.New("No task type defined")
 	}
 	if len(defs) > 1 {
-		return this, errors.Errorf("Too many task types defined: %s", strings.Join(defs, ", "))
+		return this, errors.Errorf("Too many task types defined: only one of (%s) expected", strings.Join(defs, ", "))
 	}
 
 	// TODO: validate the rest of the fields!

--- a/pkg/taskdir/definitions/definitions.go
+++ b/pkg/taskdir/definitions/definitions.go
@@ -110,6 +110,33 @@ func (this Definition) Validate() (Definition, error) {
 		return this, errors.New("Expected a task slug")
 	}
 
+	numDefs := 0
+	if this.Manual != nil {
+		numDefs++
+	}
+	if this.Deno != nil {
+		numDefs++
+	}
+	if this.Dockerfile != nil {
+		numDefs++
+	}
+	if this.Go != nil {
+		numDefs++
+	}
+	if this.Node != nil {
+		numDefs++
+	}
+	if this.Python != nil {
+		numDefs++
+	}
+
+	if numDefs == 0 {
+		return this, errors.New("No task type defined")
+	}
+	if numDefs > 1 {
+		return this, errors.New("Too many task types defined")
+	}
+
 	// TODO: validate the rest of the fields!
 
 	return this, nil

--- a/pkg/taskdir/definitions/definitions.go
+++ b/pkg/taskdir/definitions/definitions.go
@@ -2,6 +2,7 @@ package definitions
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/airplanedev/cli/pkg/api"
 	"github.com/pkg/errors"
@@ -110,31 +111,31 @@ func (this Definition) Validate() (Definition, error) {
 		return this, errors.New("Expected a task slug")
 	}
 
-	numDefs := 0
+	defs := []string{}
 	if this.Manual != nil {
-		numDefs++
+		defs = append(defs, "manual")
 	}
 	if this.Deno != nil {
-		numDefs++
+		defs = append(defs, "deno")
 	}
 	if this.Dockerfile != nil {
-		numDefs++
+		defs = append(defs, "dockerfile")
 	}
 	if this.Go != nil {
-		numDefs++
+		defs = append(defs, "go")
 	}
 	if this.Node != nil {
-		numDefs++
+		defs = append(defs, "node")
 	}
 	if this.Python != nil {
-		numDefs++
+		defs = append(defs, "python")
 	}
 
-	if numDefs == 0 {
+	if len(defs) == 0 {
 		return this, errors.New("No task type defined")
 	}
-	if numDefs > 1 {
-		return this, errors.New("Too many task types defined")
+	if len(defs) > 1 {
+		return this, errors.Errorf("Too many task types defined: %s", strings.Join(defs, ", "))
 	}
 
 	// TODO: validate the rest of the fields!


### PR DESCRIPTION
Error out if a task definition has multiple task types or no task types.