### PR TITLE
Check task kind against an explicit list for determining what needs building

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -19,7 +19,7 @@ type CreateTaskRequest struct {
 	Constraints      RunConstraints    `json:"constraints"`
 	Env              TaskEnv           `json:"env"`
 	ResourceRequests map[string]string `json:"resourceRequests"`
-	Kind             string            `json:"kind"`
+	Kind             TaskKind          `json:"kind"`
 	KindOptions      map[string]string `json:"kindOptions"`
 	Repo             string            `json:"repo"`
 	// TODO(amir): friendly type here (120s, 5m ...)
@@ -38,12 +38,23 @@ type UpdateTaskRequest struct {
 	Constraints      RunConstraints    `json:"constraints" yaml:"constraints"`
 	Env              TaskEnv           `json:"env" yaml:"env"`
 	ResourceRequests map[string]string `json:"resourceRequests" yaml:"resourceRequests"`
-	Kind             string            `json:"kind" yaml:"builder"`
+	Kind             TaskKind          `json:"kind" yaml:"builder"`
 	KindOptions      map[string]string `json:"kindOptions" yaml:"builderConfig"`
 	Repo             string            `json:"repo" yaml:"repo"`
 	// TODO(amir): friendly type here (120s, 5m ...)
 	Timeout int `json:"timeout" yaml:"timeout"`
 }
+
+type TaskKind string
+
+const (
+	TaskKindDeno   TaskKind = "deno"
+	TaskKindDocker TaskKind = "docker"
+	TaskKindGo     TaskKind = "go"
+	TaskKindManual TaskKind = ""
+	TaskKindNode   TaskKind = "node"
+	TaskKindPython TaskKind = "python"
+)
 
 type UpdateTaskResponse struct {
 	TaskRevisionID string `json:"taskRevisionID"`
@@ -254,7 +265,7 @@ type Task struct {
 	Constraints      RunConstraints   `json:"constraints" yaml:"constraints"`
 	Env              TaskEnv          `json:"env" yaml:"env"`
 	ResourceRequests ResourceRequests `json:"resourceRequests" yaml:"resourceRequests"`
-	Kind             string           `json:"kind" yaml:"kind"`
+	Kind             TaskKind         `json:"kind" yaml:"kind"`
 	KindOptions      KindOptions      `json:"kindOptions" yaml:"kindOptions"`
 	Repo             string           `json:"repo" yaml:"repo"`
 	Timeout          int              `json:"timeout" yaml:"timeout"`

--- a/pkg/build/builder.go
+++ b/pkg/build/builder.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"unicode"
 
+	"github.com/airplanedev/cli/pkg/api"
 	"github.com/airplanedev/cli/pkg/logger"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/client"
@@ -312,6 +313,15 @@ const (
 	BuilderNameNode   BuilderName = "node"
 	BuilderNameDocker BuilderName = "docker"
 )
+
+func NeedsBuilding(kind api.TaskKind) bool {
+	switch BuilderName(kind) {
+	case BuilderNameGo, BuilderNameDeno, BuilderNamePython, BuilderNameNode, BuilderNameDocker:
+		return true
+	default:
+		return false
+	}
+}
 
 func BuildDockerfile(c DockerfileConfig) (string, error) {
 	switch BuilderName(c.Builder) {

--- a/pkg/build/local.go
+++ b/pkg/build/local.go
@@ -28,7 +28,7 @@ func Local(ctx context.Context, client *api.Client, dir taskdir.TaskDirectory, d
 	}
 	b, err := New(LocalConfig{
 		Root:    dir.DefinitionRootPath(),
-		Builder: kind,
+		Builder: string(kind),
 		Args:    Args(options),
 		Auth: &RegistryAuth{
 			Token: registry.Token,

--- a/pkg/build/remote.go
+++ b/pkg/build/remote.go
@@ -74,11 +74,11 @@ func archiveTaskDir(dir taskdir.TaskDirectory, archivePath string) error {
 	if err != nil {
 		return err
 	}
-	builder, _, err := def.GetKindAndOptions()
+	kind, _, err := def.GetKindAndOptions()
 	if err != nil {
 		return err
 	}
-	arch.Tar.IncludeFunc, err = getIgnoreFunc(dir.DefinitionRootPath(), builder)
+	arch.Tar.IncludeFunc, err = getIgnoreFunc(dir.DefinitionRootPath(), kind)
 	if err != nil {
 		return err
 	}
@@ -95,8 +95,8 @@ func archiveTaskDir(dir taskdir.TaskDirectory, archivePath string) error {
 //
 // This is modeled off of docker/cli.
 // See: https://github.com/docker/cli/blob/a32cd16160f1b41c1c4ae7bee4dac929d1484e59/vendor/github.com/docker/docker/pkg/archive/archive.go#L738
-func getIgnoreFunc(taskRootPath string, builder string) (func(filePath string, info os.FileInfo) (bool, error), error) {
-	excludes, err := getIgnorePatterns(taskRootPath, builder)
+func getIgnoreFunc(taskRootPath string, kind api.TaskKind) (func(filePath string, info os.FileInfo) (bool, error), error) {
+	excludes, err := getIgnorePatterns(taskRootPath, kind)
 	if err != nil {
 		return nil, err
 	}
@@ -146,7 +146,7 @@ func getIgnoreFunc(taskRootPath string, builder string) (func(filePath string, i
 	}, nil
 }
 
-func getIgnorePatterns(path string, builder string) ([]string, error) {
+func getIgnorePatterns(path string, kind api.TaskKind) ([]string, error) {
 	// reference: https://docs.docker.com/engine/reference/builder/#dockerignore-file
 	excludes, err := dockerBuild.ReadDockerignore(path)
 	if err != nil {
@@ -164,7 +164,7 @@ func getIgnorePatterns(path string, builder string) ([]string, error) {
 		"bin",
 	}
 	// For inspiration, see: https://github.com/github/gitignore
-	switch BuilderName(builder) {
+	switch BuilderName(kind) {
 	case BuilderNameGo:
 		// https://github.com/github/gitignore/blob/master/Go.gitignore
 		return append(defaultExcludes, []string{
@@ -189,7 +189,7 @@ func getIgnorePatterns(path string, builder string) ([]string, error) {
 	case BuilderNameDocker:
 		return defaultExcludes, nil
 	default:
-		return nil, errors.Errorf("build: unknown builder type %s", builder)
+		return nil, errors.Errorf("build: unknown builder type %s", kind)
 	}
 }
 

--- a/pkg/cmd/tasks/deploy/deploy.go
+++ b/pkg/cmd/tasks/deploy/deploy.go
@@ -144,7 +144,7 @@ func run(ctx context.Context, cfg config) error {
 		return errors.Wrap(err, "getting task")
 	}
 
-	if kind != "" {
+	if build.NeedsBuilding(kind) {
 		switch builder {
 		case build.BuilderKindLocal:
 			if err := build.Local(ctx, client, dir, def, taskID); err != nil {

--- a/pkg/print/table.go
+++ b/pkg/print/table.go
@@ -49,7 +49,7 @@ func (t Table) tasks(tasks []api.Task) {
 	tw.SetCaption(true, "* indicates a required parameter")
 
 	for _, t := range tasks {
-		var builder = t.Kind
+		var builder = string(t.Kind)
 		if builder == "" {
 			builder = "manual"
 		}

--- a/pkg/print/types.go
+++ b/pkg/print/types.go
@@ -17,7 +17,7 @@ type printTask struct {
 	Constraints      api.RunConstraints   `json:"constraints" yaml:"constraints"`
 	Env              api.TaskEnv          `json:"env" yaml:"env"`
 	ResourceRequests api.ResourceRequests `json:"resourceRequests" yaml:"resourceRequests"`
-	Kind             string               `json:"builder" yaml:"builder"`
+	Kind             api.TaskKind         `json:"builder" yaml:"builder"`
 	KindOptions      api.KindOptions      `json:"builderConfig" yaml:"builderConfig"`
 	Repo             string               `json:"repo" yaml:"repo"`
 	Timeout          int                  `json:"timeout" yaml:"timeout"`

--- a/pkg/taskdir/definitions/definitions.go
+++ b/pkg/taskdir/definitions/definitions.go
@@ -29,25 +29,25 @@ func NewDefinitionFromTask(task api.Task) (Definition, error) {
 		Timeout:          task.Timeout,
 	}
 
-	if task.Kind == "deno" {
+	if task.Kind == api.TaskKindDeno {
 		deno := DenoDefinition{
 			Entrypoint: task.KindOptions["entrypoint"],
 		}
 		def.Deno = &deno
 
-	} else if task.Kind == "docker" {
+	} else if task.Kind == api.TaskKindDocker {
 		docker := DockerDefinition{
 			Dockerfile: task.KindOptions["dockerfile"],
 		}
 		def.Dockerfile = &docker
 
-	} else if task.Kind == "go" {
+	} else if task.Kind == api.TaskKindGo {
 		godef := GoDefinition{
 			Entrypoint: task.KindOptions["entrypoint"],
 		}
 		def.Go = &godef
 
-	} else if task.Kind == "node" {
+	} else if task.Kind == api.TaskKindNode {
 		node := NodeDefinition{
 			Entrypoint:  task.KindOptions["entrypoint"],
 			Language:    task.KindOptions["language"],
@@ -55,13 +55,13 @@ func NewDefinitionFromTask(task api.Task) (Definition, error) {
 		}
 		def.Node = &node
 
-	} else if task.Kind == "python" {
+	} else if task.Kind == api.TaskKindPython {
 		python := PythonDefinition{
 			Entrypoint: task.KindOptions["entrypoint"],
 		}
 		def.Python = &python
 
-	} else if task.Kind == "" {
+	} else if task.Kind == api.TaskKindManual {
 		manual := ManualDefinition{
 			Image:   task.Image,
 			Command: task.Command,
@@ -75,31 +75,31 @@ func NewDefinitionFromTask(task api.Task) (Definition, error) {
 	return def, nil
 }
 
-func (this Definition) GetKindAndOptions() (string, api.KindOptions, error) {
+func (this Definition) GetKindAndOptions() (api.TaskKind, api.KindOptions, error) {
 	if this.Deno != nil {
-		return "deno", api.KindOptions{
+		return api.TaskKindDeno, api.KindOptions{
 			"entrypoint": this.Deno.Entrypoint,
 		}, nil
 	} else if this.Dockerfile != nil {
-		return "docker", api.KindOptions{
+		return api.TaskKindDocker, api.KindOptions{
 			"dockerfile": this.Dockerfile.Dockerfile,
 		}, nil
 	} else if this.Go != nil {
-		return "go", api.KindOptions{
+		return api.TaskKindGo, api.KindOptions{
 			"entrypoint": this.Go.Entrypoint,
 		}, nil
 	} else if this.Node != nil {
-		return "node", api.KindOptions{
+		return api.TaskKindNode, api.KindOptions{
 			"entrypoint":  this.Node.Entrypoint,
 			"language":    this.Node.Language,
 			"nodeVersion": this.Node.NodeVersion,
 		}, nil
 	} else if this.Python != nil {
-		return "python", api.KindOptions{
+		return api.TaskKindPython, api.KindOptions{
 			"entrypoint": this.Python.Entrypoint,
 		}, nil
 	} else if this.Manual != nil {
-		return "", api.KindOptions{}, nil
+		return api.TaskKindManual, api.KindOptions{}, nil
 	}
 
 	return "", api.KindOptions{}, errors.New("No kind specified")


### PR DESCRIPTION
This pulls out the `NeedsBuilding` function as an explicit check & checks it against a list of task kinds that require building (rather than task kinds that _don't_ require building). Also narrows down typing of `task.Kind`. Some overlap with `BuilderName`, but they are definitely two separate concepts.