### PR TITLE
Add better YAML validation error messages

### DIFF
--- a/pkg/taskdir/definitions/definitions.go
+++ b/pkg/taskdir/definitions/definitions.go
@@ -154,7 +154,7 @@ func UnmarshalDefinition(buf []byte, defPath string) (Definition, error) {
 		// Print any "expected" validation errors
 		switch err := errors.Cause(err).(type) {
 		case ErrInvalidYAML:
-			return Definition{}, newErrReadDefinition(fmt.Sprintf("Error reading %s: invalid YAML", defPath))
+			return Definition{}, newErrReadDefinition(fmt.Sprintf("Error reading %s, invalid YAML:\n  %s", defPath, err))
 		case ErrSchemaValidation:
 			errorMsgs := []string{}
 			for _, verr := range err.Errors {

--- a/pkg/taskdir/definitions/validate.go
+++ b/pkg/taskdir/definitions/validate.go
@@ -7,10 +7,12 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-type ErrInvalidYAML struct{}
+type ErrInvalidYAML struct {
+	Msg string
+}
 
 func (this ErrInvalidYAML) Error() string {
-	return "invalid YAML"
+	return this.Msg
 }
 
 type ErrSchemaValidation struct {
@@ -26,7 +28,7 @@ func (this ErrSchemaValidation) Error() string {
 func validateYAML(data []byte, schemaObj interface{}) error {
 	var obj interface{}
 	if err := yaml.Unmarshal(data, &obj); err != nil {
-		return errors.WithStack(ErrInvalidYAML{})
+		return errors.WithStack(ErrInvalidYAML{Msg: err.Error()})
 	}
 
 	r := &jsonschema.Reflector{PreferYAMLSchema: true}


### PR DESCRIPTION
I added this while trying to figure out why this was invalid YAML:

```
constraints:
  regex: "^.*@airplane\.dev$"
```

Instead of a generic error, this now reports:

```
Error reading airplane.yml, invalid YAML:
  yaml: line 11: found unknown escape character
```
