### PR TITLE
Fix boolean default value

### DIFF
--- a/pkg/cmd/tasks/execute/cli_inputs.go
+++ b/pkg/cmd/tasks/execute/cli_inputs.go
@@ -94,11 +94,17 @@ func promptForParam(param api.Parameter) (survey.Prompt, error) {
 	}
 	switch param.Type {
 	case api.TypeBoolean:
+		var dv interface{}
+		if defaultValue == "" {
+			dv = nil
+		} else {
+			dv = defaultValue
+		}
 		return &survey.Select{
 			Message: message,
 			Help:    param.Desc,
 			Options: []string{params.YesString, params.NoString},
-			Default: defaultValue,
+			Default: dv,
 		}, nil
 	default:
 		return &survey.Input{


### PR DESCRIPTION
On boolean value prompt, if you just press enter (without moving the selector), the selector _looks_ like it'll default to "Yes", but it doesn't actually default to yes. It will actually end up sending a null value, which is a terrible idea.

Before:
```
? Is suspended (--is_suspended): 
? Execute? Yes
```

After:
```
? Is suspended (--is_suspended): Yes
? Execute? Yes
```