### PR TITLE
Fix multiple task parameters

### DIFF
--- a/pkg/cmd/tasks/execute/execute.go
+++ b/pkg/cmd/tasks/execute/execute.go
@@ -193,6 +193,7 @@ func flagset(task api.Task, args api.Values) *flag.FlagSet {
 	}
 
 	for _, p := range task.Parameters {
+		p := p
 		set.Func(p.Slug, p.Desc, func(v string) (err error) {
 			args[p.Slug], err = params.ParseInput(p, v)
 			if err != nil {

--- a/pkg/cmd/tasks/execute/execute.go
+++ b/pkg/cmd/tasks/execute/execute.go
@@ -192,8 +192,10 @@ func flagset(task api.Task, args api.Values) *flag.FlagSet {
 		logger.Log("")
 	}
 
-	for _, p := range task.Parameters {
-		p := p
+	for i := range task.Parameters {
+		// Scope p here (& not above) so we can use it in the closure.
+		// See also: https://github.com/golang/go/wiki/CommonMistakes#using-goroutines-on-loop-iterator-variables
+		p := task.Parameters[i]
 		set.Func(p.Slug, p.Desc, func(v string) (err error) {
 			args[p.Slug], err = params.ParseInput(p, v)
 			if err != nil {


### PR DESCRIPTION
Before:
```
$ airplane execute sql_suspend_user -- --email bob@example.com --is_suspended true
invalid value "bob@example.com" for flag -email: converting input to API value: strconv.ParseBool: parsing "bpb@example.com": invalid syntax

Suspend a user Usage:
  --email A user's email (default: "")
  --is_suspended True to suspend the user. (default: "")


Error: invalid value "bob@example.com" for flag -email: converting input to API value: strconv.ParseBool: parsing "bob@example.com": invalid syntax
```

See also: https://github.com/golang/go/wiki/CommonMistakes#using-goroutines-on-loop-iterator-variables