### PR TITLE
Filter out nil param values

### DIFF
--- a/pkg/cmd/tasks/execute/cli_inputs.go
+++ b/pkg/cmd/tasks/execute/cli_inputs.go
@@ -70,7 +70,9 @@ func promptForParamValues(client *api.Client, task api.Task, paramValues map[str
 		if err != nil {
 			return err
 		}
-		paramValues[param.Slug] = value
+		if value != nil {
+			paramValues[param.Slug] = value
+		}
 	}
 	confirmed := false
 	if err := survey.AskOne(&survey.Confirm{


### PR DESCRIPTION
Previously this would send param values as `{"foo": null}`, if `foo` was optional & unspecified. It now sends `{}` instead.