### PR TITLE
Change deploy to match new build API

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -381,8 +381,9 @@ type GetBuildResponse struct {
 }
 
 type CreateBuildRequest struct {
-	TaskRevisionID string `json:"taskRevisionID"`
-	SourceUploadID string `json:"sourceUploadID"`
+	TaskID         string  `json:"taskID"`
+	SourceUploadID string  `json:"sourceUploadID"`
+	Env            TaskEnv `json:"env"`
 }
 
 type CreateBuildResponse struct {

--- a/pkg/build/remote.go
+++ b/pkg/build/remote.go
@@ -21,7 +21,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-func Remote(ctx context.Context, dir taskdir.TaskDirectory, client *api.Client, taskRevisionID string) error {
+func Remote(ctx context.Context, dir taskdir.TaskDirectory, client *api.Client, taskID string, env api.TaskEnv) error {
 	tmpdir, err := ioutil.TempDir("", "airplane-builds-")
 	if err != nil {
 		return errors.Wrap(err, "creating temporary directory for remote build")
@@ -39,8 +39,9 @@ func Remote(ctx context.Context, dir taskdir.TaskDirectory, client *api.Client, 
 	}
 
 	build, err := client.CreateBuild(ctx, api.CreateBuildRequest{
-		TaskRevisionID: taskRevisionID,
+		TaskID:         taskID,
 		SourceUploadID: uploadID,
+		Env:            env,
 	})
 	if err != nil {
 		return errors.Wrap(err, "creating build")

--- a/pkg/cmd/tasks/deploy/deploy.go
+++ b/pkg/cmd/tasks/deploy/deploy.go
@@ -88,12 +88,11 @@ func run(ctx context.Context, cfg config) error {
 	}
 
 	var taskID string
-	var taskRevisionID string
 	task, err := client.GetTask(ctx, def.Slug)
 	if err == nil {
 		// This task already exists, so we update it:
 		logger.Log("Updating task...")
-		res, err := client.UpdateTask(ctx, api.UpdateTaskRequest{
+		_, err := client.UpdateTask(ctx, api.UpdateTaskRequest{
 			Slug:             def.Slug,
 			Name:             def.Name,
 			Description:      def.Description,
@@ -115,7 +114,6 @@ func run(ctx context.Context, cfg config) error {
 		}
 
 		taskID = task.ID
-		taskRevisionID = res.TaskRevisionID
 	} else if aerr, ok := err.(api.Error); ok && aerr.Code == 404 {
 		// A task with this slug does not exist, so we should create one.
 		logger.Log("Creating task...")
@@ -141,7 +139,6 @@ func run(ctx context.Context, cfg config) error {
 		}
 
 		taskID = res.TaskID
-		taskRevisionID = res.TaskRevisionID
 	} else {
 		return errors.Wrap(err, "getting task")
 	}
@@ -153,7 +150,7 @@ func run(ctx context.Context, cfg config) error {
 				return err
 			}
 		case build.BuilderKindRemote:
-			if err := build.Remote(ctx, dir, client, taskRevisionID); err != nil {
+			if err := build.Remote(ctx, dir, client, taskID, def.Env); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
Changes deploy command to match the new builds API, instead of creating and sending
a task revision it just sends the task env and task_id.