### PR TITLE
Create a new revision on build

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -1,0 +1,37 @@
+package build
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/airplanedev/cli/pkg/api"
+	"github.com/airplanedev/cli/pkg/taskdir"
+	"github.com/airplanedev/cli/pkg/taskdir/definitions"
+)
+
+// Request represents a build request.
+type Request struct {
+	Builder BuilderKind
+	Client  *api.Client
+	Dir     taskdir.TaskDirectory
+	Def     definitions.Definition
+	TaskID  string
+	TaskEnv api.TaskEnv
+}
+
+// Response represents a build response.
+type Response struct {
+	ImageURL string
+}
+
+// Run runs the build and returns an image URL.
+func Run(ctx context.Context, req Request) (*Response, error) {
+	switch req.Builder {
+	case BuilderKindLocal:
+		return local(ctx, req)
+	case BuilderKindRemote:
+		return remote(ctx, req)
+	default:
+		return nil, fmt.Errorf("build: unknown builder %q", req.Builder)
+	}
+}

--- a/pkg/build/local.go
+++ b/pkg/build/local.go
@@ -6,28 +6,27 @@ import (
 	"github.com/airplanedev/cli/pkg/api"
 	"github.com/airplanedev/cli/pkg/configs"
 	"github.com/airplanedev/cli/pkg/logger"
-	"github.com/airplanedev/cli/pkg/taskdir"
 	"github.com/airplanedev/cli/pkg/taskdir/definitions"
 	"github.com/pkg/errors"
 )
 
-func Local(ctx context.Context, client *api.Client, dir taskdir.TaskDirectory, def definitions.Definition, taskID string) error {
-	registry, err := client.GetRegistryToken(ctx)
+func local(ctx context.Context, req Request) (*Response, error) {
+	registry, err := req.Client.GetRegistryToken(ctx)
 	if err != nil {
-		return errors.Wrap(err, "getting registry token")
+		return nil, errors.Wrap(err, "getting registry token")
 	}
 
-	buildEnv, err := getBuildEnv(ctx, client, def)
+	buildEnv, err := getBuildEnv(ctx, req.Client, req.Def)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	kind, options, err := def.GetKindAndOptions()
+	kind, options, err := req.Def.GetKindAndOptions()
 	if err != nil {
-		return err
+		return nil, err
 	}
 	b, err := New(LocalConfig{
-		Root:    dir.DefinitionRootPath(),
+		Root:    req.Dir.DefinitionRootPath(),
 		Builder: string(kind),
 		Args:    Args(options),
 		Auth: &RegistryAuth{
@@ -37,21 +36,21 @@ func Local(ctx context.Context, client *api.Client, dir taskdir.TaskDirectory, d
 		BuildEnv: buildEnv,
 	})
 	if err != nil {
-		return errors.Wrap(err, "new build")
+		return nil, errors.Wrap(err, "new build")
 	}
 
 	logger.Log("Building...")
-	bo, err := b.Build(ctx, taskID, "latest")
+	resp, err := b.Build(ctx, req.TaskID, "latest")
 	if err != nil {
-		return errors.Wrap(err, "build")
+		return nil, errors.Wrap(err, "build")
 	}
 
 	logger.Log("Pushing...")
-	if err := b.Push(ctx, bo.Tag); err != nil {
-		return errors.Wrap(err, "push")
+	if err := b.Push(ctx, resp.ImageURL); err != nil {
+		return nil, errors.Wrap(err, "push")
 	}
 
-	return nil
+	return resp, nil
 }
 
 // Retreives a build env from def - looks for env vars starting with BUILD_ and either uses the

--- a/pkg/build/remote.go
+++ b/pkg/build/remote.go
@@ -21,38 +21,51 @@ import (
 	"github.com/pkg/errors"
 )
 
-func Remote(ctx context.Context, dir taskdir.TaskDirectory, client *api.Client, taskID string, env api.TaskEnv) error {
+func remote(ctx context.Context, req Request) (*Response, error) {
+	registry, err := req.Client.GetRegistryToken(ctx)
+	if err != nil {
+		return nil, errors.Wrap(err, "getting registry token")
+	}
+
 	tmpdir, err := ioutil.TempDir("", "airplane-builds-")
 	if err != nil {
-		return errors.Wrap(err, "creating temporary directory for remote build")
+		return nil, errors.Wrap(err, "creating temporary directory for remote build")
 	}
 	defer os.RemoveAll(tmpdir)
 
 	archivePath := path.Join(tmpdir, "archive.tar.gz")
-	if err := archiveTaskDir(dir, archivePath); err != nil {
-		return err
+	if err := archiveTaskDir(req.Dir, archivePath); err != nil {
+		return nil, err
 	}
 
-	uploadID, err := uploadArchive(ctx, client, archivePath)
+	uploadID, err := uploadArchive(ctx, req.Client, archivePath)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	build, err := client.CreateBuild(ctx, api.CreateBuildRequest{
-		TaskID:         taskID,
+	build, err := req.Client.CreateBuild(ctx, api.CreateBuildRequest{
+		TaskID:         req.TaskID,
 		SourceUploadID: uploadID,
-		Env:            env,
+		Env:            req.TaskEnv,
 	})
 	if err != nil {
-		return errors.Wrap(err, "creating build")
+		return nil, errors.Wrap(err, "creating build")
 	}
 	logger.Debug("Created build with id=%s", build.Build.ID)
 
-	if err := waitForBuild(ctx, client, build.Build.ID); err != nil {
-		return err
+	if err := waitForBuild(ctx, req.Client, build.Build.ID); err != nil {
+		return nil, err
 	}
 
-	return nil
+	imageURL := fmt.Sprintf("%s/task-%s:bld_%s",
+		registry.Repo,
+		sanitizeTaskID(req.TaskID),
+		build.Build.ID,
+	)
+
+	return &Response{
+		ImageURL: imageURL,
+	}, nil
 }
 
 func archiveTaskDir(dir taskdir.TaskDirectory, archivePath string) error {

--- a/pkg/build/remote.go
+++ b/pkg/build/remote.go
@@ -57,7 +57,7 @@ func remote(ctx context.Context, req Request) (*Response, error) {
 		return nil, err
 	}
 
-	imageURL := fmt.Sprintf("%s/task-%s:bld_%s",
+	imageURL := fmt.Sprintf("%s/task-%s:%s",
 		registry.Repo,
 		sanitizeTaskID(req.TaskID),
 		build.Build.ID,


### PR DESCRIPTION
Changed the deploy command to create a new task revision with the image URL
once the build succeeds.

I had to refactor the `build` package a bit to unify the remote vs local builders
so we can treat both the same way from the `deploy` command.
