### PR TITLE
Add shim-based Node builder

### DIFF
--- a/cmd/shimtest/main.go
+++ b/cmd/shimtest/main.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/airplanedev/cli/pkg/api"
+	"github.com/airplanedev/cli/pkg/build"
+	"github.com/airplanedev/cli/pkg/conf"
+	"github.com/airplanedev/cli/pkg/taskdir"
+	"github.com/airplanedev/cli/pkg/taskdir/definitions"
+)
+
+// This is used to test the Node.js shim. It will be removed
+// before merging and replaced by a future PR adding
+// support for deploying via the standard `deploy` command.
+func main() {
+	if len(os.Args) != 3 {
+		fmt.Printf("shimtest [filepath] [host]")
+		os.Exit(1)
+	}
+	path := os.Args[1]
+	host := os.Args[2]
+
+	client := &api.Client{
+		Host: host,
+	}
+	if c, err := conf.ReadDefault(); err != nil {
+		fmt.Printf("client error: %+v", err)
+	} else {
+		client.Token = c.Tokens["api.airplane.so:5000"]
+	}
+
+	dir, err := taskdir.New(path)
+	if err != nil {
+		fmt.Printf("filepath error: %+v", err)
+	}
+
+	if resp, err := build.Run(context.Background(), build.Request{
+		Builder: build.BuilderKindLocal,
+		Client:  client,
+		Dir:     dir,
+		Def: definitions.Definition(definitions.Definition_0_2{
+			Node: &definitions.NodeDefinition{
+				Entrypoint: path,
+			},
+		}),
+		TaskID:  "123",
+		TaskEnv: api.TaskEnv{},
+	}); err != nil {
+		fmt.Printf("build error: %+v", err)
+		os.Exit(1)
+	} else {
+		fmt.Printf("resp: %+v", resp)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/segmentio/events/v2 v2.4.0
 	github.com/spf13/cobra v1.1.3
 	github.com/stretchr/testify v1.6.1
+	github.com/tidwall/gjson v1.8.0
 	github.com/ulikunitz/xz v0.5.10 // indirect
 	github.com/xeipuuv/gojsonschema v1.2.0
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c

--- a/go.sum
+++ b/go.sum
@@ -1017,6 +1017,12 @@ github.com/tdakkota/asciicheck v0.0.0-20200416190851-d7f85be797a2/go.mod h1:yHp0
 github.com/tdakkota/asciicheck v0.0.0-20200416200610-e657995f937b/go.mod h1:yHp0ai0Z9gUljN3o0xMhYJnH/IcvkdTBOX2fmJ93JEM=
 github.com/tetafro/godot v0.3.7/go.mod h1:/7NLHhv08H1+8DNj0MElpAACw1ajsCuf3TKNQxA5S+0=
 github.com/tetafro/godot v0.4.2/go.mod h1:/7NLHhv08H1+8DNj0MElpAACw1ajsCuf3TKNQxA5S+0=
+github.com/tidwall/gjson v1.8.0 h1:Qt+orfosKn0rbNTZqHYDqBrmm3UDA4KRkv70fDzG+PQ=
+github.com/tidwall/gjson v1.8.0/go.mod h1:5/xDoumyyDNerp2U36lyolv46b3uF/9Bu6OfyQ9GImk=
+github.com/tidwall/match v1.0.3 h1:FQUVvBImDutD8wJLN6c5eMzWtjgONK9MwIBCOrUJKeE=
+github.com/tidwall/match v1.0.3/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
+github.com/tidwall/pretty v1.1.0 h1:K3hMW5epkdAVwibsQEfR/7Zj0Qgt4DxtNumTq/VloO8=
+github.com/tidwall/pretty v1.1.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/timakin/bodyclose v0.0.0-20190930140734-f7f2e9bca95e/go.mod h1:Qimiffbc6q9tBWlVV6x0P9sat/ao1xEkREYPPj9hphk=
 github.com/timakin/bodyclose v0.0.0-20200424151742-cb6215831a94/go.mod h1:Qimiffbc6q9tBWlVV6x0P9sat/ao1xEkREYPPj9hphk=
 github.com/tj/assert v0.0.0-20171129193455-018094318fb0/go.mod h1:mZ9/Rh9oLWpLLDRpvE+3b7gP/C2YyLFYxNmcLnPTMe0=

--- a/pkg/build/builder.go
+++ b/pkg/build/builder.go
@@ -6,6 +6,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"html/template"
 	"os"
 	"path"
 	"path/filepath"
@@ -334,4 +335,18 @@ func BuildDockerfile(c DockerfileConfig) (string, error) {
 	default:
 		return "", errors.Errorf("build: unknown builder type %q", c.Builder)
 	}
+}
+
+func templatize(t string, data interface{}) (string, error) {
+	tmpl, err := template.New("airplane").Parse(t)
+	if err != nil {
+		return "", errors.Wrap(err, "parsing template")
+	}
+
+	var buf strings.Builder
+	if err := tmpl.Execute(&buf, data); err != nil {
+		return "", err
+	}
+
+	return buf.String(), nil
 }

--- a/pkg/build/builder.go
+++ b/pkg/build/builder.go
@@ -115,7 +115,7 @@ type Builder struct {
 // New returns a new local builder with c.
 func New(c LocalConfig) (*Builder, error) {
 	if !filepath.IsAbs(c.Root) {
-		return nil, fmt.Errorf("build: expected an absolute path, got %q", c.Root)
+		return nil, fmt.Errorf("build: expected an absolute root path, got %q", c.Root)
 	}
 
 	if c.Builder == "" {

--- a/pkg/build/local.go
+++ b/pkg/build/local.go
@@ -54,9 +54,9 @@ func local(ctx context.Context, req Request) (*Response, error) {
 	}
 
 	logger.Log("Pushing...")
-	// if err := b.Push(ctx, resp.ImageURL); err != nil {
-	// 	return nil, errors.Wrap(err, "push")
-	// }
+	if err := b.Push(ctx, resp.ImageURL); err != nil {
+		return nil, errors.Wrap(err, "push")
+	}
 
 	return resp, nil
 }

--- a/pkg/build/local.go
+++ b/pkg/build/local.go
@@ -54,9 +54,9 @@ func local(ctx context.Context, req Request) (*Response, error) {
 	}
 
 	logger.Log("Pushing...")
-	if err := b.Push(ctx, resp.ImageURL); err != nil {
-		return nil, errors.Wrap(err, "push")
-	}
+	// if err := b.Push(ctx, resp.ImageURL); err != nil {
+	// 	return nil, errors.Wrap(err, "push")
+	// }
 
 	return resp, nil
 }

--- a/pkg/build/node.go
+++ b/pkg/build/node.go
@@ -54,8 +54,6 @@ func node(root string, args Args) (string, error) {
 	// import paths with `.ts` endings. `.js` endings are fine.
 	relimport = strings.TrimSuffix(relimport, ".ts")
 
-	// TODO: test this with strict ts
-	// TODO: add some friendly errors to this shim for common errors.
 	shim := `// This file includes a shim that will execute your task code.
 import task from "../` + relimport + `"
 

--- a/pkg/build/node.go
+++ b/pkg/build/node.go
@@ -10,6 +10,7 @@ import (
 	"github.com/pkg/errors"
 )
 
+// node creates a dockerfile for Node (typescript/javascript).
 func node(root string, args Args) (string, error) {
 	var err error
 
@@ -116,7 +117,7 @@ func templatize(t string, data interface{}) (string, error) {
 	return buf.String(), nil
 }
 
-// Node creates a dockerfile for Node (typescript/javascript).
+// nodeOld creates a dockerfile for Node (typescript/javascript).
 //
 // TODO(amir): possibly just run `npm start` instead of exposing lots
 // of options to users?

--- a/pkg/build/node.go
+++ b/pkg/build/node.go
@@ -10,17 +10,122 @@ import (
 	"github.com/pkg/errors"
 )
 
+func node(root string, args Args) (string, error) {
+	var err error
+
+	// For backwards compatibility, continue to build old Node tasks
+	// in the same way. Tasks built with the latest CLI will set
+	// shim=true which enables the new code path.
+	if shim := args["shim"]; shim != "true" {
+		return nodeOld(root, args)
+	}
+
+	// Assert that the entrypoint file exists:
+	entrypoint := filepath.Join(root, args["entrypoint"])
+	if err := exist(entrypoint); err != nil {
+		return "", err
+	}
+
+	cfg := struct {
+		Base           string
+		Entrypoint     string
+		HasPackageJSON bool
+		HasPackageLock bool
+		HasYarnLock    bool
+		CreateTSConfig bool
+		HasTSConfig    bool
+		RunTSC         bool
+	}{
+		HasPackageJSON: exist(filepath.Join(root, "package.json")) == nil,
+		HasPackageLock: exist(filepath.Join(root, "package-lock.json")) == nil,
+		HasYarnLock:    exist(filepath.Join(root, "yarn.lock")) == nil,
+	}
+
+	cfg.Base, err = getBaseNodeImage(args["nodeVersion"])
+	if err != nil {
+		return "", err
+	}
+
+	if args["language"] == "typescript" {
+		cfg.RunTSC = true
+		cfg.HasTSConfig = exist(filepath.Join(root, "tsconfig.json")) == nil
+		// If a tsconfig.json was not provided, insert a default one:
+		cfg.CreateTSConfig = !cfg.HasTSConfig
+		// Point the entrypoint at the compiled JS version of the entrypoint.
+		// TODO: consider using ts-node
+		cfg.Entrypoint = filepath.Join(".airplane-build", strings.TrimSuffix(entrypoint, ".ts")+".js")
+	} else {
+		cfg.Entrypoint = entrypoint
+	}
+
+	// TODO: do we want to support buildDir and buildCommand still?
+	return templatize(`
+		FROM {{.Base}}
+
+		WORKDIR /airplane
+
+		# Support setting BUILD_NPM_RC or BUILD_NPM_TOKEN to configure private registry auth
+		ARG BUILD_NPM_RC
+		ARG BUILD_NPM_TOKEN
+		RUN [ -z "${BUILD_NPM_RC}" ] || echo "${BUILD_NPM_RC}" > .npmrc
+		RUN [ -z "${BUILD_NPM_TOKEN}" ] || echo "//registry.npmjs.org/:_authToken=${BUILD_NPM_TOKEN}" > .npmrc
+
+		{{if .RunTSC}}
+		RUN npm install -g typescript@4.2
+		{{end}}
+
+		{{if .HasPackageJSON}}
+		COPY package.json .
+		{{else}}
+		RUN echo '{"type":"module"}' > package.json
+		{{end}}
+
+		{{if .HasTSConfig}}
+		COPY tsconfig.json .
+		{{else if .CreateTSConfig}}
+		RUN echo '{"include": ["*", "**/*"], "exclude": ["node_modules"]}' > tsconfig.json
+		{{end}}
+
+		{{if .HasPackageLock}}
+		RUN npm install package-lock.json
+		{{else if .HasYarnLock}}
+		RUN yarn install
+		{{end}}
+
+		COPY . .
+
+		{{if .RunTSC}}
+		RUN mkdir .airplane-build && tsc --outDir .airplane-build --rootDir .
+		{{end}}
+
+		ENTRYPOINT ["node", "--input-type=module", "{{ .Main }}"]
+	`, cfg)
+}
+
+func templatize(t string, data interface{}) (string, error) {
+	tmpl, err := template.New("airplane").Parse(t)
+	if err != nil {
+		return "", errors.Wrap(err, "parsing template")
+	}
+
+	var buf strings.Builder
+	if err := tmpl.Execute(&buf, data); err != nil {
+		return "", err
+	}
+
+	return buf.String(), nil
+}
+
 // Node creates a dockerfile for Node (typescript/javascript).
 //
 // TODO(amir): possibly just run `npm start` instead of exposing lots
 // of options to users?
-func node(root string, args Args) (string, error) {
+func nodeOld(root string, args Args) (string, error) {
 	var entrypoint = args["entrypoint"]
 	var main = filepath.Join(root, entrypoint)
 	var deps = filepath.Join(root, "package.json")
 	var yarnlock = filepath.Join(root, "yarn.lock")
 	var pkglock = filepath.Join(root, "package-lock.json")
-	var version = args["nodeVersion"]
 	var lang = args["language"]
 	// `workdir` is fixed usually - `buildWorkdir` is a subdirectory of `workdir` if there's
 	// `buildCommand` and is ultimately where `entrypoint` is run from.
@@ -70,30 +175,45 @@ func node(root string, args Args) (string, error) {
 	}
 	entrypoint = path.Join(buildWorkdir, entrypoint)
 
-	// Dockerfile template.
-	t, err := template.New("node").Parse(`
-FROM {{ .Base }}
-
-WORKDIR {{ .Workdir }}
-
-# Support setting BUILD_NPM_RC or BUILD_NPM_TOKEN to configure private registry auth
-ARG BUILD_NPM_RC
-ARG BUILD_NPM_TOKEN
-RUN [ -z "${BUILD_NPM_RC}" ] || echo "${BUILD_NPM_RC}" > .npmrc
-RUN [ -z "${BUILD_NPM_TOKEN}" ] || echo "//registry.npmjs.org/:_authToken=${BUILD_NPM_TOKEN}" > .npmrc
-
-COPY . {{ .Workdir }}
-{{ range .Commands }}
-RUN {{ . }}
-{{ end }}
-
-WORKDIR {{ .BuildWorkdir }}
-ENTRYPOINT ["node", "{{ .Main }}"]
-`)
+	baseImage, err := getBaseNodeImage(args["nodeVersion"])
 	if err != nil {
 		return "", err
 	}
 
+	return templatize(`
+		FROM {{ .Base }}
+		
+		WORKDIR {{ .Workdir }}
+		
+		# Support setting BUILD_NPM_RC or BUILD_NPM_TOKEN to configure private registry auth
+		ARG BUILD_NPM_RC
+		ARG BUILD_NPM_TOKEN
+		RUN [ -z "${BUILD_NPM_RC}" ] || echo "${BUILD_NPM_RC}" > .npmrc
+		RUN [ -z "${BUILD_NPM_TOKEN}" ] || echo "//registry.npmjs.org/:_authToken=${BUILD_NPM_TOKEN}" > .npmrc
+		
+		COPY . {{ .Workdir }}
+		{{ range .Commands }}
+		RUN {{ . }}
+		{{ end }}
+		
+		WORKDIR {{ .BuildWorkdir }}
+		ENTRYPOINT ["node", "{{ .Main }}"]
+	`, struct {
+		Base         string
+		Workdir      string
+		BuildWorkdir string
+		Commands     []string
+		Main         string
+	}{
+		Base:         baseImage,
+		Workdir:      workdir,
+		BuildWorkdir: buildWorkdir,
+		Commands:     cmds,
+		Main:         entrypoint,
+	})
+}
+
+func getBaseNodeImage(version string) (string, error) {
 	if version == "" {
 		version = "15"
 	}
@@ -107,22 +227,5 @@ ENTRYPOINT ["node", "{{ .Main }}"]
 		base = "node:" + version + "-buster"
 	}
 
-	var buf strings.Builder
-	if err := t.Execute(&buf, struct {
-		Base         string
-		Workdir      string
-		BuildWorkdir string
-		Commands     []string
-		Main         string
-	}{
-		Base:         base,
-		Workdir:      workdir,
-		BuildWorkdir: buildWorkdir,
-		Commands:     cmds,
-		Main:         entrypoint,
-	}); err != nil {
-		return "", err
-	}
-
-	return buf.String(), nil
+	return base, nil
 }

--- a/pkg/build/node.go
+++ b/pkg/build/node.go
@@ -18,7 +18,7 @@ func node(root string, args Args) (string, error) {
 	// in the same way. Tasks built with the latest CLI will set
 	// shim=true which enables the new code path.
 	if shim := args["shim"]; shim != "true" {
-		return nodeOld(root, args)
+		return nodeLegacyBuilder(root, args)
 	}
 
 	// Assert that the entrypoint file exists:
@@ -158,11 +158,11 @@ func templatize(t string, data interface{}) (string, error) {
 	return buf.String(), nil
 }
 
-// nodeOld creates a dockerfile for Node (typescript/javascript).
+// nodeLegacyBuilder creates a dockerfile for Node (typescript/javascript).
 //
 // TODO(amir): possibly just run `npm start` instead of exposing lots
 // of options to users?
-func nodeOld(root string, args Args) (string, error) {
+func nodeLegacyBuilder(root string, args Args) (string, error) {
 	var entrypoint = args["entrypoint"]
 	var main = filepath.Join(root, entrypoint)
 	var deps = filepath.Join(root, "package.json")

--- a/pkg/build/node.go
+++ b/pkg/build/node.go
@@ -59,6 +59,7 @@ func node(root string, args Args) (string, error) {
 		cfg.Entrypoint = entrypoint
 	}
 
+	// TODO: insert shim!
 	// TODO: do we want to support buildDir and buildCommand still?
 	return templatize(`
 		FROM {{.Base}}

--- a/pkg/build/node.go
+++ b/pkg/build/node.go
@@ -5,7 +5,6 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
-	"text/template"
 
 	"github.com/pkg/errors"
 )
@@ -143,20 +142,6 @@ main()`
 				.airplane-build/shim.ts
 		ENTRYPOINT ["node", ".airplane-build/dist/.airplane-build/shim.js"]
 	`, cfg)
-}
-
-func templatize(t string, data interface{}) (string, error) {
-	tmpl, err := template.New("airplane").Parse(t)
-	if err != nil {
-		return "", errors.Wrap(err, "parsing template")
-	}
-
-	var buf strings.Builder
-	if err := tmpl.Execute(&buf, data); err != nil {
-		return "", err
-	}
-
-	return buf.String(), nil
 }
 
 // nodeLegacyBuilder creates a dockerfile for Node (typescript/javascript).

--- a/pkg/taskdir/definitions/definitions.go
+++ b/pkg/taskdir/definitions/definitions.go
@@ -100,6 +100,11 @@ func (this Definition) GetKindAndOptions() (api.TaskKind, api.KindOptions, error
 		if err := mapstructure.Decode(this.Node, &options); err != nil {
 			return "", api.KindOptions{}, errors.Wrap(err, "decoding Node definition")
 		}
+		// Node tasks built with older versions of the CLI will have `shim=false` which
+		// instructs the remote builder to build Node tasks using the old (non-shim) version.
+		//
+		// We can remove this after we roll out this new JS task syntax to our existing users.
+		options["shim"] = "true"
 		return api.TaskKindNode, options, nil
 	} else if this.Python != nil {
 		if err := mapstructure.Decode(this.Python, &options); err != nil {


### PR DESCRIPTION
This PR adds a new version of the Node builder that uses a shim to execute Node tasks. This will be opt-in by using the new version of the CLI, so old versions of the CLI will continue to work.