### PR TITLE
Deploy changes

### DIFF
--- a/cmd/shimtest/main.go
+++ b/cmd/shimtest/main.go
@@ -40,7 +40,7 @@ func main() {
 	if resp, err := build.Run(context.Background(), build.Request{
 		Builder: build.BuilderKindLocal,
 		Client:  client,
-		Dir:     dir,
+		Root:    dir.DefinitionRootPath(),
 		Def: definitions.Definition(definitions.Definition_0_2{
 			Node: &definitions.NodeDefinition{
 				Entrypoint: path,

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/airplanedev/cli/pkg/api"
-	"github.com/airplanedev/cli/pkg/taskdir"
 	"github.com/airplanedev/cli/pkg/taskdir/definitions"
 )
 
@@ -13,7 +12,7 @@ import (
 type Request struct {
 	Builder BuilderKind
 	Client  *api.Client
-	Dir     taskdir.TaskDirectory
+	Root    string
 	Def     definitions.Definition
 	TaskID  string
 	TaskEnv api.TaskEnv

--- a/pkg/build/local.go
+++ b/pkg/build/local.go
@@ -34,7 +34,7 @@ func local(ctx context.Context, req Request) (*Response, error) {
 		}
 	}
 	b, err := New(LocalConfig{
-		Root:    req.Dir.DefinitionRootPath(),
+		Root:    req.Root,
 		Builder: string(kind),
 		Args:    args,
 		Auth: &RegistryAuth{

--- a/pkg/cmd/tasks/deploy/deploy.go
+++ b/pkg/cmd/tasks/deploy/deploy.go
@@ -2,17 +2,14 @@ package deploy
 
 import (
 	"context"
-	"fmt"
+	"path/filepath"
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/airplanedev/cli/pkg/api"
 	"github.com/airplanedev/cli/pkg/build"
 	"github.com/airplanedev/cli/pkg/cli"
 	"github.com/airplanedev/cli/pkg/cmd/auth/login"
-	"github.com/airplanedev/cli/pkg/logger"
-	"github.com/airplanedev/cli/pkg/taskdir"
 	"github.com/airplanedev/cli/pkg/utils"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -31,6 +28,8 @@ func New(c *cli.Config) *cobra.Command {
 		Long:  "Deploy a task from a YAML-based task definition",
 		Example: heredoc.Doc(`
 			airplane tasks deploy my-task.yml
+			airplane tasks deploy task.ts
+			airplane tasks deploy task.js
 		`),
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -48,145 +47,11 @@ func New(c *cli.Config) *cobra.Command {
 }
 
 func run(ctx context.Context, cfg config) error {
-	var client = cfg.client
+	var ext = filepath.Ext(cfg.file)
 
-	builder, err := build.ToBuilderKind(cfg.builder)
-	if err != nil {
-		return err
+	if ext == ".yml" || ext == ".yaml" {
+		return deployFromYaml(ctx, cfg)
 	}
 
-	dir, err := taskdir.Open(cfg.file)
-	if err != nil {
-		return err
-	}
-	defer dir.Close()
-
-	def, err := dir.ReadDefinition()
-	if err != nil {
-		return err
-	}
-
-	if def, err = def.Validate(); err != nil {
-		return err
-	}
-
-	if err := ensureConfigsExist(ctx, client, def); err != nil {
-		return err
-	}
-
-	kind, kindOptions, err := def.GetKindAndOptions()
-	if err != nil {
-		return err
-	}
-
-	var image *string
-	var command []string
-	if def.Manual != nil {
-		image = &def.Manual.Image
-		command = def.Manual.Command
-	}
-
-	task, err := client.GetTask(ctx, def.Slug)
-	if aerr, ok := err.(api.Error); ok && aerr.Code == 404 {
-		// A task with this slug does not exist, so we should create one.
-		logger.Log("Creating task...")
-		_, err := client.CreateTask(ctx, api.CreateTaskRequest{
-			Slug:             def.Slug,
-			Name:             def.Name,
-			Description:      def.Description,
-			Image:            image,
-			Command:          command,
-			Arguments:        def.Arguments,
-			Parameters:       def.Parameters,
-			Constraints:      def.Constraints,
-			Env:              def.Env,
-			ResourceRequests: def.ResourceRequests,
-			Resources:        def.Resources,
-			Kind:             kind,
-			KindOptions:      kindOptions,
-			Repo:             def.Repo,
-			Timeout:          def.Timeout,
-		})
-		if err != nil {
-			return errors.Wrapf(err, "creating task %s", def.Slug)
-		}
-
-		task, err = client.GetTask(ctx, def.Slug)
-		if err != nil {
-			return errors.Wrap(err, "fetching created task")
-		}
-	} else {
-		return errors.Wrap(err, "getting task")
-	}
-
-	if build.NeedsBuilding(kind) {
-		// Before performing a remote build, we must first update kind/kindOptions
-		// since the remote build relies on pulling those from the tasks table (for now).
-		_, err := client.UpdateTask(ctx, api.UpdateTaskRequest{
-			Kind:        kind,
-			KindOptions: kindOptions,
-
-			// The following fields are not updated until after the build finishes.
-			Slug:             task.Slug,
-			Name:             task.Name,
-			Description:      task.Description,
-			Image:            task.Image,
-			Command:          task.Command,
-			Arguments:        task.Arguments,
-			Parameters:       task.Parameters,
-			Constraints:      task.Constraints,
-			Env:              task.Env,
-			ResourceRequests: task.ResourceRequests,
-			Resources:        task.Resources,
-			Repo:             task.Repo,
-			Timeout:          task.Timeout,
-		})
-		if err != nil {
-			return errors.Wrapf(err, "updating task %s", def.Slug)
-		}
-
-		resp, err := build.Run(ctx, build.Request{
-			Builder: builder,
-			Client:  client,
-			Dir:     dir,
-			Def:     def,
-			TaskID:  task.ID,
-		})
-		if err != nil {
-			return err
-		}
-		image = &resp.ImageURL
-	}
-
-	_, err = client.UpdateTask(ctx, api.UpdateTaskRequest{
-		Slug:             def.Slug,
-		Name:             def.Name,
-		Description:      def.Description,
-		Image:            image,
-		Command:          command,
-		Arguments:        def.Arguments,
-		Parameters:       def.Parameters,
-		Constraints:      def.Constraints,
-		Env:              def.Env,
-		ResourceRequests: def.ResourceRequests,
-		Resources:        def.Resources,
-		Kind:             kind,
-		KindOptions:      kindOptions,
-		Repo:             def.Repo,
-		Timeout:          def.Timeout,
-	})
-	if err != nil {
-		return errors.Wrapf(err, "updating task %s", def.Slug)
-	}
-
-	cmd := fmt.Sprintf("airplane execute %s", def.Slug)
-	if len(def.Parameters) > 0 {
-		cmd += " -- [parameters]"
-	}
-	logger.Log(`
-To execute %s:
-- From the CLI: %s
-- From the UI: %s`, def.Name, cmd, client.TaskURL(def.Slug))
-
-	return nil
+	return deployFromScript(ctx, cfg)
 }

--- a/pkg/cmd/tasks/deploy/script.go
+++ b/pkg/cmd/tasks/deploy/script.go
@@ -60,7 +60,7 @@ func deployFromScript(ctx context.Context, cfg config) error {
 		return err
 	}
 
-	def.Node = &definitions.NodeDefinition{}
+	def.Node.Entrypoint = cfg.file
 
 	resp, err := build.Run(ctx, build.Request{
 		Builder: buildkind,

--- a/pkg/cmd/tasks/deploy/script.go
+++ b/pkg/cmd/tasks/deploy/script.go
@@ -60,7 +60,7 @@ func deployFromScript(ctx context.Context, cfg config) error {
 		return err
 	}
 
-	def.Node.Entrypoint = cfg.file
+	def.Node.Entrypoint = filepath.Base(abs)
 
 	resp, err := build.Run(ctx, build.Request{
 		Builder: buildkind,
@@ -84,7 +84,7 @@ func deployFromScript(ctx context.Context, cfg config) error {
 		Name:             def.Name,
 		Description:      def.Description,
 		Image:            &resp.ImageURL,
-		Command:          []string{"node", cfg.file},
+		Command:          []string{},
 		Arguments:        def.Arguments,
 		Parameters:       def.Parameters,
 		Constraints:      def.Constraints,

--- a/pkg/cmd/tasks/deploy/script.go
+++ b/pkg/cmd/tasks/deploy/script.go
@@ -1,0 +1,131 @@
+package deploy
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+
+	"github.com/airplanedev/cli/pkg/api"
+	"github.com/airplanedev/cli/pkg/build"
+	"github.com/airplanedev/cli/pkg/logger"
+	"github.com/airplanedev/cli/pkg/runtime"
+	"github.com/airplanedev/cli/pkg/taskdir/definitions"
+)
+
+// DeployFromScript deploys from the given script.
+func deployFromScript(ctx context.Context, cfg config) error {
+	var client = cfg.client
+	var ext = filepath.Ext(cfg.file)
+
+	if ext == "" {
+		return errors.New("cannot deploy a file without extension")
+	}
+
+	r, ok := runtime.Lookup(cfg.file)
+	if !ok {
+		return fmt.Errorf("cannot deploy a file with extension of %q", ext)
+	}
+
+	code, err := ioutil.ReadFile(cfg.file)
+	if err != nil {
+		return fmt.Errorf("reading %s - %w", cfg.file, err)
+	}
+
+	slug, ok := r.Slug(code)
+	if !ok {
+		return errors.New("")
+	}
+
+	task, err := client.GetTask(ctx, slug)
+	if err != nil {
+		return err
+	}
+
+	def, err := definitions.NewDefinitionFromTask(task)
+	if err != nil {
+		return err
+	}
+
+	buildkind, err := build.ToBuilderKind("local")
+	if err != nil {
+		return err
+	}
+
+	abs, err := filepath.Abs(cfg.file)
+	if err != nil {
+		return err
+	}
+
+	def.Node = &definitions.NodeDefinition{}
+
+	resp, err := build.Run(ctx, build.Request{
+		Builder: buildkind,
+		Client:  client,
+		TaskID:  task.ID,
+		Root:    filepath.Dir(abs),
+		Def:     def,
+		TaskEnv: def.Env,
+	})
+	if err != nil {
+		return err
+	}
+
+	kind, kindOptions, err := def.GetKindAndOptions()
+	if err != nil {
+		return err
+	}
+
+	_, err = client.UpdateTask(ctx, api.UpdateTaskRequest{
+		Slug:             def.Slug,
+		Name:             def.Name,
+		Description:      def.Description,
+		Image:            resp.ImageURL,
+		Command:          []string{"node", cfg.file},
+		Arguments:        def.Arguments,
+		Parameters:       def.Parameters,
+		Constraints:      def.Constraints,
+		Env:              def.Env,
+		ResourceRequests: def.ResourceRequests,
+		Resources:        def.Resources,
+		Kind:             kind,
+		KindOptions:      kindOptions,
+		Repo:             def.Repo,
+		Timeout:          def.Timeout,
+	})
+	if err != nil {
+		return err
+	}
+
+	cmd := fmt.Sprintf("airplane execute %s", cfg.file)
+	if len(def.Parameters) > 0 {
+		cmd += " -- [parameters]"
+	}
+	logger.Log(`
+To execute %s:
+- From the CLI: %s
+- From the UI: %s`, def.Name, cmd, client.TaskURL(task.Slug))
+	return nil
+}
+
+// Unlinked explains an unlinked code error.
+type unlinked struct {
+	path string
+}
+
+// Error implementation.
+func (u unlinked) Error() string {
+	return fmt.Sprintf(
+		"the file %s is not linked to a task",
+		u.path,
+	)
+}
+
+// ExplainError implementation.
+func (u unlinked) ExplainError() string {
+	return fmt.Sprintf(
+		"You can link the file by running:\n\tairplane init --slug <slug> %s",
+		u.path,
+	)
+}

--- a/pkg/cmd/tasks/deploy/script.go
+++ b/pkg/cmd/tasks/deploy/script.go
@@ -50,7 +50,7 @@ func deployFromScript(ctx context.Context, cfg config) error {
 		return err
 	}
 
-	buildkind, err := build.ToBuilderKind("local")
+	buildkind, err := build.ToBuilderKind(cfg.builder)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/tasks/deploy/script.go
+++ b/pkg/cmd/tasks/deploy/script.go
@@ -35,7 +35,9 @@ func deployFromScript(ctx context.Context, cfg config) error {
 
 	slug, ok := r.Slug(code)
 	if !ok {
-		return errors.New("")
+		return &unlinked{
+			path: cfg.file,
+		}
 	}
 
 	task, err := client.GetTask(ctx, slug)
@@ -81,7 +83,7 @@ func deployFromScript(ctx context.Context, cfg config) error {
 		Slug:             def.Slug,
 		Name:             def.Name,
 		Description:      def.Description,
-		Image:            resp.ImageURL,
+		Image:            &resp.ImageURL,
 		Command:          []string{"node", cfg.file},
 		Arguments:        def.Arguments,
 		Parameters:       def.Parameters,

--- a/pkg/cmd/tasks/deploy/yaml.go
+++ b/pkg/cmd/tasks/deploy/yaml.go
@@ -113,7 +113,7 @@ func deployFromYaml(ctx context.Context, cfg config) error {
 		resp, err := build.Run(ctx, build.Request{
 			Builder: builder,
 			Client:  client,
-			Dir:     dir,
+			Root:    dir.DefinitionRootPath(),
 			Def:     def,
 			TaskID:  task.ID,
 		})

--- a/pkg/cmd/tasks/deploy/yaml.go
+++ b/pkg/cmd/tasks/deploy/yaml.go
@@ -1,0 +1,157 @@
+package deploy
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/airplanedev/cli/pkg/api"
+	"github.com/airplanedev/cli/pkg/build"
+	"github.com/airplanedev/cli/pkg/logger"
+	"github.com/airplanedev/cli/pkg/taskdir"
+	"github.com/pkg/errors"
+)
+
+// DeployFromYaml deploys from a yaml file.
+func deployFromYaml(ctx context.Context, cfg config) error {
+	var client = cfg.client
+
+	builder, err := build.ToBuilderKind(cfg.builder)
+	if err != nil {
+		return err
+	}
+
+	dir, err := taskdir.Open(cfg.file)
+	if err != nil {
+		return err
+	}
+	defer dir.Close()
+
+	def, err := dir.ReadDefinition()
+	if err != nil {
+		return err
+	}
+
+	if def, err = def.Validate(); err != nil {
+		return err
+	}
+
+	if err := ensureConfigsExist(ctx, client, def); err != nil {
+		return err
+	}
+
+	kind, kindOptions, err := def.GetKindAndOptions()
+	if err != nil {
+		return err
+	}
+
+	var image *string
+	var command []string
+	if def.Manual != nil {
+		image = &def.Manual.Image
+		command = def.Manual.Command
+	}
+
+	task, err := client.GetTask(ctx, def.Slug)
+	if aerr, ok := err.(api.Error); ok && aerr.Code == 404 {
+		// A task with this slug does not exist, so we should create one.
+		logger.Log("Creating task...")
+		_, err := client.CreateTask(ctx, api.CreateTaskRequest{
+			Slug:             def.Slug,
+			Name:             def.Name,
+			Description:      def.Description,
+			Image:            image,
+			Command:          command,
+			Arguments:        def.Arguments,
+			Parameters:       def.Parameters,
+			Constraints:      def.Constraints,
+			Env:              def.Env,
+			ResourceRequests: def.ResourceRequests,
+			Resources:        def.Resources,
+			Kind:             kind,
+			KindOptions:      kindOptions,
+			Repo:             def.Repo,
+			Timeout:          def.Timeout,
+		})
+		if err != nil {
+			return errors.Wrapf(err, "creating task %s", def.Slug)
+		}
+
+		task, err = client.GetTask(ctx, def.Slug)
+		if err != nil {
+			return errors.Wrap(err, "fetching created task")
+		}
+	} else {
+		return errors.Wrap(err, "getting task")
+	}
+
+	if build.NeedsBuilding(kind) {
+		// Before performing a remote build, we must first update kind/kindOptions
+		// since the remote build relies on pulling those from the tasks table (for now).
+		_, err := client.UpdateTask(ctx, api.UpdateTaskRequest{
+			Kind:        kind,
+			KindOptions: kindOptions,
+
+			// The following fields are not updated until after the build finishes.
+			Slug:             task.Slug,
+			Name:             task.Name,
+			Description:      task.Description,
+			Image:            task.Image,
+			Command:          task.Command,
+			Arguments:        task.Arguments,
+			Parameters:       task.Parameters,
+			Constraints:      task.Constraints,
+			Env:              task.Env,
+			ResourceRequests: task.ResourceRequests,
+			Resources:        task.Resources,
+			Repo:             task.Repo,
+			Timeout:          task.Timeout,
+		})
+		if err != nil {
+			return errors.Wrapf(err, "updating task %s", def.Slug)
+		}
+
+		resp, err := build.Run(ctx, build.Request{
+			Builder: builder,
+			Client:  client,
+			Dir:     dir,
+			Def:     def,
+			TaskID:  task.ID,
+		})
+		if err != nil {
+			return err
+		}
+		image = &resp.ImageURL
+	}
+
+	_, err = client.UpdateTask(ctx, api.UpdateTaskRequest{
+		Slug:             def.Slug,
+		Name:             def.Name,
+		Description:      def.Description,
+		Image:            image,
+		Command:          command,
+		Arguments:        def.Arguments,
+		Parameters:       def.Parameters,
+		Constraints:      def.Constraints,
+		Env:              def.Env,
+		ResourceRequests: def.ResourceRequests,
+		Resources:        def.Resources,
+		Kind:             kind,
+		KindOptions:      kindOptions,
+		Repo:             def.Repo,
+		Timeout:          def.Timeout,
+	})
+	if err != nil {
+		return errors.Wrapf(err, "updating task %s", def.Slug)
+	}
+
+	cmd := fmt.Sprintf("airplane execute %s", def.Slug)
+	if len(def.Parameters) > 0 {
+		cmd += " -- [parameters]"
+	}
+	logger.Log(`
+To execute %s:
+- From the CLI: %s
+- From the UI: %s`, def.Name, cmd, client.TaskURL(def.Slug))
+
+	return nil
+}


### PR DESCRIPTION
The goal of the PR is to allow users to deploy like so:

```bash
$ airplane deploy task.yml
$ airplane deploy task.yaml
$ airplane deploy task.js
$ airplane deploy task.ts
```

To do this, i had to change the builder to not depend on `taskdir`, since scripts don't
have definitions and the taskdir relies on them.

I also had to hardcode serveral things (like file extensions, kinds etc) but this is just
so we get it running and working, the next PRs will improve the quality here by relying
on `runtime.Interface` to do those things.

The PR also omits package.json detection, we still need to figure out how to do this:

- Do we do it at `init`? if so, where do we persist the state, how can someone change it?
- Do we do it at `deploy`? if so, wouldn't it get annoying to always say yes to prompts before deploys?

Currently, we just do `filepath.Dir('task.js')` and treat that as the root.
