### PR TITLE
Fix issues with shim builder

### DIFF
--- a/pkg/build/builder.go
+++ b/pkg/build/builder.go
@@ -6,11 +6,11 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"html/template"
 	"os"
 	"path"
 	"path/filepath"
 	"strings"
+	"text/template"
 	"unicode"
 
 	"github.com/airplanedev/cli/pkg/api"

--- a/pkg/build/deno.go
+++ b/pkg/build/deno.go
@@ -1,9 +1,9 @@
 package build
 
 import (
-	"html/template"
 	"path/filepath"
 	"strings"
+	"text/template"
 
 	"github.com/pkg/errors"
 )

--- a/pkg/build/golang.go
+++ b/pkg/build/golang.go
@@ -1,9 +1,9 @@
 package build
 
 import (
-	"html/template"
 	"path/filepath"
 	"strings"
+	"text/template"
 
 	"github.com/pkg/errors"
 )

--- a/pkg/build/node.go
+++ b/pkg/build/node.go
@@ -123,7 +123,7 @@ main()`
 		{{else if .HasYarnLock}}
 		RUN yarn install && yarn add -D @types/node
 		{{else}}
-		npm install @types/node
+		RUN npm install @types/node
 		{{end}}
 
 		COPY . .
@@ -243,7 +243,7 @@ func nodeLegacyBuilder(root string, args Args) (string, error) {
 
 func getBaseNodeImage(version string) (string, error) {
 	if version == "" {
-		version = "15"
+		version = "16"
 	}
 	v, err := GetVersion(BuilderNameNode, version)
 	if err != nil {


### PR DESCRIPTION
This PR fixes two issues with the new Node.js shim builder.
1. We were using `html/template` which was escaping quotes and other characters in `shim.ts`. Moving to `text/template` disables escaping.
2. Missing `RUN` command when not using npm or yarn.

It also updates the default Node version to 16 in a place that I missed in a previous PR.