### PR TITLE
Add check to prevent segfault when deploying non-node tasks via scripts

### DIFF
--- a/pkg/cmd/tasks/deploy/script.go
+++ b/pkg/cmd/tasks/deploy/script.go
@@ -60,7 +60,6 @@ func deployFromScript(ctx context.Context, cfg config) error {
 		return err
 	}
 
-	logger.Debug("def: %+v", def)
 	def.Node.Entrypoint = filepath.Base(abs)
 
 	resp, err := build.Run(ctx, build.Request{

--- a/pkg/cmd/tasks/deploy/script.go
+++ b/pkg/cmd/tasks/deploy/script.go
@@ -45,7 +45,7 @@ func deployFromScript(ctx context.Context, cfg config) error {
 		return err
 	}
 
-	// TODO: move this into `runtime`
+	// TODO: make the expected kind a property of the `runtime`
 	if task.Kind != api.TaskKindNode {
 		return fmt.Errorf("'%s' is a %s task. Expected a %s task.", task.Name, task.Kind, api.TaskKindNode)
 	}

--- a/pkg/cmd/tasks/deploy/script.go
+++ b/pkg/cmd/tasks/deploy/script.go
@@ -45,6 +45,11 @@ func deployFromScript(ctx context.Context, cfg config) error {
 		return err
 	}
 
+	// TODO: move this into `runtime`
+	if task.Kind != api.TaskKindNode {
+		return fmt.Errorf("'%s' is a %s task. Expected a %s task.", task.Name, task.Kind, api.TaskKindNode)
+	}
+
 	def, err := definitions.NewDefinitionFromTask(task)
 	if err != nil {
 		return err
@@ -55,6 +60,7 @@ func deployFromScript(ctx context.Context, cfg config) error {
 		return err
 	}
 
+	logger.Debug("def: %+v", def)
 	def.Node.Entrypoint = filepath.Base(abs)
 
 	resp, err := build.Run(ctx, build.Request{


### PR DESCRIPTION
I ran into a segfault when deploying a python task from a JS script. AD in a previous PR, we'll want to push this down into `runtime`, but for now just adding a quick check to surface a better error.