### PR TITLE
init validation

### DIFF
--- a/pkg/api/client.go
+++ b/pkg/api/client.go
@@ -190,6 +190,14 @@ func (c Client) GetOutputs(ctx context.Context, runID string) (res GetOutputsRes
 func (c Client) GetTask(ctx context.Context, slug string) (res Task, err error) {
 	q := url.Values{"slug": []string{slug}}
 	err = c.do(ctx, "GET", "/tasks/get?"+q.Encode(), nil, &res)
+
+	if err, ok := err.(Error); ok && err.Code == 404 {
+		return res, &TaskMissingError{
+			app:  c.appURL().String(),
+			slug: slug,
+		}
+	}
+
 	if err != nil {
 		return
 	}

--- a/pkg/api/client.go
+++ b/pkg/api/client.go
@@ -193,8 +193,8 @@ func (c Client) GetTask(ctx context.Context, slug string) (res Task, err error) 
 
 	if err, ok := err.(Error); ok && err.Code == 404 {
 		return res, &TaskMissingError{
-			app:  c.appURL().String(),
-			slug: slug,
+			appURL: c.appURL().String(),
+			slug:   slug,
 		}
 	}
 

--- a/pkg/api/errors.go
+++ b/pkg/api/errors.go
@@ -1,0 +1,22 @@
+package api
+
+import "fmt"
+
+// TaskMissingError implements an exaplainable error.
+type TaskMissingError struct {
+	app  string
+	slug string
+}
+
+// Error implementation.
+func (err TaskMissingError) Error() string {
+	return fmt.Sprintf("task with slug %q does not exist", err.slug)
+}
+
+// ExplainError implementation.
+func (err TaskMissingError) ExplainError() string {
+	return fmt.Sprintf(
+		"Follow the URL below to create the task:\n%s",
+		err.app+"/tasks/new",
+	)
+}

--- a/pkg/api/errors.go
+++ b/pkg/api/errors.go
@@ -4,8 +4,8 @@ import "fmt"
 
 // TaskMissingError implements an exaplainable error.
 type TaskMissingError struct {
-	app  string
-	slug string
+	appURL string
+	slug   string
 }
 
 // Error implementation.
@@ -17,6 +17,6 @@ func (err TaskMissingError) Error() string {
 func (err TaskMissingError) ExplainError() string {
 	return fmt.Sprintf(
 		"Follow the URL below to create the task:\n%s",
-		err.app+"/tasks/new",
+		err.appURL+"/tasks/new",
 	)
 }

--- a/pkg/cmd/tasks/initcmd/init.go
+++ b/pkg/cmd/tasks/initcmd/init.go
@@ -52,6 +52,7 @@ func New(c *cli.Config) *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&cfg.slug, "slug", "", "Slug of an existing task to generate from.")
+	cmd.MarkFlagRequired("slug")
 
 	return cmd
 }


### PR DESCRIPTION
Improves `init` command validation and error messages:

#### Missing `--slug`

Before:
```bash
$ ap init task.ts
Error: api: 404 - Could not find task
```

After:
```bash
$ ap init task.ts
Error: required flag(s) "slug" not set
```

#### Task not found

Before:
```bash
$ ap init --slug foo task.ts
Error: api: 404 - Could not find task
```

After:
```bash
$ ap init --slug foo task.ts

task with slug "foo" does not exist

Follow the URL below to create the task:
https://app.airplane.dev/tasks/new
```