### PR TITLE
Fix creating tasks from YAML

### DIFF
--- a/pkg/cmd/tasks/deploy/yaml.go
+++ b/pkg/cmd/tasks/deploy/yaml.go
@@ -47,7 +47,7 @@ func deployFromYaml(ctx context.Context, cfg config) error {
 	}
 
 	task, err := client.GetTask(ctx, def.Slug)
-	if aerr, ok := err.(api.Error); ok && aerr.Code == 404 {
+	if _, ok := err.(*api.TaskMissingError); ok {
 		// A task with this slug does not exist, so we should create one.
 		logger.Log("Creating task...")
 		_, err := client.CreateTask(ctx, api.CreateTaskRequest{


### PR DESCRIPTION
Creating tasks from YAML was broken with the introduction of TaskMissingError; this needs to check for that instead of a generic `api.Error`.