### PR TITLE
Add runtime.Kind()

### DIFF
--- a/pkg/cmd/tasks/deploy/script.go
+++ b/pkg/cmd/tasks/deploy/script.go
@@ -46,9 +46,8 @@ func deployFromScript(ctx context.Context, cfg config) error {
 		return err
 	}
 
-	// TODO: make the expected kind a property of the `runtime`
-	if task.Kind != api.TaskKindNode {
-		return fmt.Errorf("'%s' is a %s task. Expected a %s task.", task.Name, task.Kind, api.TaskKindNode)
+	if task.Kind != r.Kind() {
+		return fmt.Errorf("'%s' is a %s task. Expected a %s task.", task.Name, task.Kind, r.Kind())
 	}
 
 	def, err := definitions.NewDefinitionFromTask(task)

--- a/pkg/cmd/tasks/initcmd/init.go
+++ b/pkg/cmd/tasks/initcmd/init.go
@@ -76,8 +76,8 @@ func run(ctx context.Context, cfg config) error {
 		return err
 	}
 
-	if task.Kind != api.TaskKindNode {
-		return fmt.Errorf("cannot link %q to a non node.js task", cfg.file)
+	if task.Kind != r.Kind() {
+		return fmt.Errorf("cannot link %q to a %s task", cfg.file, r.Kind())
 	}
 
 	if fs.Exists(cfg.file) {

--- a/pkg/runtime/javascript/javascript.go
+++ b/pkg/runtime/javascript/javascript.go
@@ -84,3 +84,8 @@ func (r Runtime) Comment(t api.Task) string {
 func (r Runtime) Root(path string) (dir string, ok bool) {
 	return runtime.Pathof(path, "package.json")
 }
+
+// Kind implementation.
+func (r Runtime) Kind() api.TaskKind {
+	return api.TaskKindNode
+}

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -41,6 +41,12 @@ type Interface interface {
 	// Typically runtimes will look for a specific file such as
 	// `package.json` or `requirements.txt`, they'll use `runtime.Pathof()`.
 	Root(path string) (dir string, ok bool)
+
+	// Kind returns a task kind that matches the runtime.
+	//
+	// Generate and other methods should not be called
+	// for a task that doesn't match the returned kind.
+	Kind() api.TaskKind
 }
 
 // Runtimes is a collection of registered runtimes.


### PR DESCRIPTION
Previously we hardcoded api.TaskKindNode checks, this PR moves
that check to the runtime, that way adding a new runtime becomes
a bit easier.
