### PR TITLE
Rename "args" to "params" in init-ed script

### DIFF
--- a/pkg/runtime/javascript/javascript.go
+++ b/pkg/runtime/javascript/javascript.go
@@ -26,8 +26,8 @@ const (
 // Code template.
 var code = template.Must(template.New("js").Parse(`{{.Comment}}
 
-export default async function(args){
-  console.log('arguments: ', args);
+export default async function(params){
+  console.log('parameters: ', params);
 }
 `))
 


### PR DESCRIPTION
This is more consistent with our UI ("parameters")
