### PR TITLE
Error when task is not deployed

### DIFF
--- a/cmd/airplane/main.go
+++ b/cmd/airplane/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"os"
+	"strings"
 
 	"github.com/airplanedev/cli/pkg/cmd/root"
 	"github.com/airplanedev/cli/pkg/logger"
@@ -33,14 +34,21 @@ func main() {
 		}
 		logger.Log("")
 		if exerr, ok := errors.Cause(err).(utils.ErrorExplained); ok {
-			logger.Log(logger.Red(exerr.Error()))
+			logger.Error(capitalize(exerr.Error()))
 			logger.Log("")
-			logger.Log(exerr.ExplainError())
+			logger.Log(capitalize(exerr.ExplainError()))
 		} else {
-			logger.Error(errors.Cause(err).Error())
+			logger.Error(capitalize(errors.Cause(err).Error()))
 		}
 		logger.Log("")
 
 		os.Exit(1)
 	}
+}
+
+func capitalize(str string) string {
+	if len(str) > 0 {
+		return strings.ToUpper(str[0:1]) + str[1:]
+	}
+	return str
 }

--- a/pkg/cmd/tasks/execute/execute.go
+++ b/pkg/cmd/tasks/execute/execute.go
@@ -73,6 +73,12 @@ func run(ctx context.Context, cfg config) error {
 		return errors.Wrap(err, "get task")
 	}
 
+	if task.Image == nil {
+		return &notDeployedError{
+			task: cfg.task,
+		}
+	}
+
 	req := api.RunTaskRequest{
 		TaskID:      task.ID,
 		ParamValues: make(api.Values),
@@ -237,4 +243,18 @@ func slugFromScript(file string) (string, error) {
 	}
 
 	return slug, nil
+}
+
+type notDeployedError struct {
+	task string
+}
+
+// Error implementation.
+func (err notDeployedError) Error() string {
+	return fmt.Sprintf("task %s was not deployed", err.task)
+}
+
+// ExplainError implementation.
+func (err notDeployedError) ExplainError() string {
+	return fmt.Sprintf("to deploy the task:\n\tairplane deploy %s", err.task)
 }


### PR DESCRIPTION
Previously, if you attempt to execute a task that was not deployed
yet the CLI will ask you for parameters and attempt to execute the task
even though it was not deployed.

After this PR, the CLI will error asking you to deploy it.

```bash
  λ tasks apdev exec ./test_js/index.js               

task ./test_js/index.js was not deployed

to deploy the task:
	airplane deploy ./test_js/index.js
```
