### PR TITLE
Support node.js workspaces

### DIFF
--- a/pkg/build/node.go
+++ b/pkg/build/node.go
@@ -27,6 +27,7 @@ func node(root string, args Args) (string, error) {
 	}
 
 	cfg := struct {
+		Workdir        string
 		Base           string
 		HasPackageJSON bool
 		HasPackageLock bool
@@ -36,12 +37,17 @@ func node(root string, args Args) (string, error) {
 		TscTarget      string
 		TscLib         string
 	}{
+		Workdir:        args["workdir"],
 		HasPackageJSON: exist(filepath.Join(root, "package.json")) == nil,
 		HasPackageLock: exist(filepath.Join(root, "package-lock.json")) == nil,
 		HasYarnLock:    exist(filepath.Join(root, "yarn.lock")) == nil,
 		// https://github.com/tsconfig/bases/blob/master/bases/node16.json
 		TscTarget: "es2020",
 		TscLib:    "es2020",
+	}
+
+	if !strings.HasPrefix(cfg.Workdir, "/") {
+		cfg.Workdir = "/" + cfg.Workdir
 	}
 
 	nodeVersion := args["nodeVersion"]
@@ -102,7 +108,7 @@ main()`
 	return templatize(`
 		FROM {{.Base}}
 
-		WORKDIR /airplane
+		WORKDIR /airplane{{.Workdir}}
 
 		# Support setting BUILD_NPM_RC or BUILD_NPM_TOKEN to configure private registry auth
 		ARG BUILD_NPM_RC

--- a/pkg/cmd/tasks/deploy/script.go
+++ b/pkg/cmd/tasks/deploy/script.go
@@ -72,6 +72,10 @@ func deployFromScript(ctx context.Context, cfg config) error {
 		def.Node.Entrypoint = filepath.Base(abs)
 	}
 
+	if wd, err := r.Workdir(abs); err == nil {
+		def.Node.Workdir = strings.TrimPrefix(wd, taskroot)
+	}
+
 	kind, kindOptions, err := def.GetKindAndOptions()
 	if err != nil {
 		return err

--- a/pkg/cmd/tasks/deploy/script.go
+++ b/pkg/cmd/tasks/deploy/script.go
@@ -65,7 +65,7 @@ func deployFromScript(ctx context.Context, cfg config) error {
 	// in the build.
 	var taskroot = filepath.Dir(abs)
 
-	if root, ok := r.Root(abs); ok {
+	if root, err := r.Root(abs); err == nil {
 		def.Node.Entrypoint = strings.TrimPrefix(abs, root)
 		taskroot = root
 	} else {

--- a/pkg/runtime/javascript/javascript.go
+++ b/pkg/runtime/javascript/javascript.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/airplanedev/cli/pkg/api"
 	"github.com/airplanedev/cli/pkg/runtime"
+	"github.com/pkg/errors"
 )
 
 // Init register the runtime.

--- a/pkg/runtime/javascript/javascript.go
+++ b/pkg/runtime/javascript/javascript.go
@@ -101,7 +101,7 @@ func (r Runtime) Root(path string) (string, error) {
 	pkgjson := filepath.Join(dst, "package.json")
 	buf, err := ioutil.ReadFile(pkgjson)
 	if err != nil {
-		return "", fmt.Errorf("javascript: reading %s - %w", dst, err)
+		return "", errors.Wrapf(err, "javascript: reading %s", dst)
 	}
 
 	var pkg struct {

--- a/pkg/runtime/javascript/javascript.go
+++ b/pkg/runtime/javascript/javascript.go
@@ -83,6 +83,11 @@ func (r Runtime) Comment(t api.Task) string {
 	return fmt.Sprintf("%s\n// %s", commentPrefix, t.URL)
 }
 
+// Workdir implementation.
+func (r Runtime) Workdir(path string) (string, error) {
+	return runtime.Pathof(path, "package.json")
+}
+
 // Root implementation.
 //
 // The method finds the nearest package.json, If the package.json contains

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -46,6 +46,13 @@ type Interface interface {
 	// The comment links a remote task to a file.
 	Comment(task api.Task) string
 
+	// Workdir attempts to detect the root of the given task path.
+	//
+	// Unlike root it decides the dockerfile's `workdir` directive
+	// this might be different than root because it decides where
+	// the build commands are run.
+	Workdir(path string) (dir string, err error)
+
 	// Root attempts to detect the root of the given task path.
 	//
 	// It returns the suggested root, if a root directory is not

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -17,7 +17,7 @@ import (
 )
 
 var (
-	// ErrMissing is returend when a resource was not found.
+	// ErrMissing is returned when a resource was not found.
 	//
 	// It can be checked via `errors.Is(err, ErrMissing)`.
 	ErrMissing = errors.New("runtime: resource is missing")

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -8,12 +8,25 @@
 package runtime
 
 import (
+	"errors"
 	"fmt"
 	"path/filepath"
 
 	"github.com/airplanedev/cli/pkg/api"
 	"github.com/airplanedev/cli/pkg/fs"
 )
+
+var (
+	// ErrMissing is returend when a resource was not found.
+	//
+	// It can be checked via `errors.Is(err, ErrMissing)`.
+	ErrMissing = errors.New("runtime: resource is missing")
+)
+
+// Settings represent Airplane specific settings.
+type Settings struct {
+	Root string `json:"root"`
+}
 
 // Interface repersents a runtime.
 type Interface interface {
@@ -35,12 +48,12 @@ type Interface interface {
 
 	// Root attempts to detect the root of the given task path.
 	//
-	// It returns the suggested root and `ok=true` if a suggestion
-	// was found otherwise it returns an empty string.
+	// It returns the suggested root, if a root directory is not
+	// found the method returns an `ErrMissing`.
 	//
 	// Typically runtimes will look for a specific file such as
 	// `package.json` or `requirements.txt`, they'll use `runtime.Pathof()`.
-	Root(path string) (dir string, ok bool)
+	Root(path string) (dir string, err error)
 
 	// Kind returns a task kind that matches the runtime.
 	//
@@ -77,18 +90,18 @@ const (
 // Pathof attempts to find the path of the given filename.
 //
 // The method recursively visits parent dirs until the given
-// filename is found, ok reports if the filename is found
-// and the string is the path.
-func Pathof(parent, filename string) (string, bool) {
+// filename is found, If the file is not found the method
+// returns an `ErrMissing`.
+func Pathof(parent, filename string) (string, error) {
 	dst := filepath.Join(parent, filename)
 
 	if !fs.Exists(dst) {
-		if parent == sep {
-			return "", false
-		}
 		next := filepath.Dir(parent)
+		if next == "." || next == sep {
+			return "", ErrMissing
+		}
 		return Pathof(next, filename)
 	}
 
-	return parent, true
+	return parent, nil
 }

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -1,6 +1,7 @@
 package runtime
 
 import (
+	"errors"
 	"path/filepath"
 	"testing"
 
@@ -14,9 +15,9 @@ func TestRuntime(t *testing.T) {
 			var path = "testdata/my/task/with_package_json"
 			var filename = "package.json"
 
-			v, ok := Pathof(path, filename)
+			v, err := Pathof(path, filename)
 
-			assert.True(ok)
+			assert.Nil(err)
 			assert.Equal("with_package_json", filepath.Base(v))
 		})
 
@@ -25,21 +26,22 @@ func TestRuntime(t *testing.T) {
 			var path = "testdata/monorepo/my/task"
 			var filename = "package.json"
 
-			v, ok := Pathof(path, filename)
+			v, err := Pathof(path, filename)
 
-			assert.True(ok)
+			assert.Nil(err)
 			assert.Equal("monorepo", filepath.Base(v))
 		})
 
 		t.Run("missing package.json", func(t *testing.T) {
 			var assert = require.New(t)
-			var path = "testdata/monorepo/my/task"
+			var path = "testdata"
 			var filename = "package.json"
 
-			v, ok := Pathof(path, filename)
+			v, err := Pathof(path, filename)
 
-			assert.True(ok)
-			assert.Equal("monorepo", filepath.Base(v))
+			assert.Error(err)
+			assert.True(errors.Is(err, ErrMissing), "expected a runtime.ErrMissing")
+			assert.Equal("", v)
 		})
 	})
 }

--- a/pkg/taskdir/definitions/def_0_2.go
+++ b/pkg/taskdir/definitions/def_0_2.go
@@ -55,6 +55,7 @@ type GoDefinition struct {
 }
 
 type NodeDefinition struct {
+	Workdir     string `yaml:"workdir" mapstructure:"workdir"`
 	Entrypoint  string `yaml:"entrypoint" mapstructure:"entrypoint"`
 	Language    string `yaml:"language" mapstructure:"language"`
 	NodeVersion string `yaml:"nodeVersion" mapstructure:"nodeVersion"`


### PR DESCRIPTION
The PR adds support to `node.js` workspaces, it does this by allowing users
to define an "airplane" settings key within package.json:

```json
{
  "airplane": {
     "root": ".."
  }
}
```

There's an [example](https://github.com/airplanedev/examples/pull/10) of this working and some guide on how to it works, but
i'll mention it again here. Users define `airplane.root` key within the nearest
package.json, on deploy we detect that key and ensure we treat it as the root.

From there our node.js dockerfile does most of the work by calling `yarn` or `npm`
to install all dependencies and the task is executed successfully.
