### PR TITLE
Redirect to web success page instead of docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 dist/
 bin/
+.DS_Store

--- a/pkg/api/client.go
+++ b/pkg/api/client.go
@@ -72,6 +72,13 @@ func (c Client) LoginURL(uri string) string {
 	return u.String()
 }
 
+// LoginSuccessURL returns a URL showing a message that logging in was successful.
+func (c Client) LoginSuccessURL() string {
+	u := c.appURL()
+	u.Path = "/cli/success"
+	return u.String()
+}
+
 // RunURL returns a run URL for a run ID.
 func (c Client) RunURL(id string) string {
 	u := c.appURL()

--- a/pkg/cmd/auth/login/login.go
+++ b/pkg/cmd/auth/login/login.go
@@ -69,7 +69,7 @@ func isLoggedIn(c *cli.Config) bool {
 }
 
 func login(ctx context.Context, c *cli.Config) error {
-	srv, err := token.NewServer(ctx)
+	srv, err := token.NewServer(ctx, c.Client.LoginSuccessURL())
 	if err != nil {
 		return err
 	}

--- a/pkg/token/server_test.go
+++ b/pkg/token/server_test.go
@@ -13,7 +13,7 @@ func TestServer(t *testing.T) {
 		var ctx = context.Background()
 		var assert = require.New(t)
 
-		srv, err := NewServer(ctx)
+		srv, err := NewServer(ctx, "https://fake.airplane.so/cli/success")
 		assert.NoError(err)
 
 		send(t, srv.URL(), "token")


### PR DESCRIPTION
After signing in, redirect to /cli/success so that we can show a better
success page (and so we can remove this from the docs, where it shows up
in the sidebar and is confusing).

See https://github.com/airplanedev/web/pull/383
