### PR TITLE
Clarify `do not edit` nature of linking comment

### DIFF
--- a/pkg/cmd/tasks/deploy/script.go
+++ b/pkg/cmd/tasks/deploy/script.go
@@ -34,7 +34,7 @@ func deployFromScript(ctx context.Context, cfg config) error {
 		return fmt.Errorf("reading %s - %w", cfg.file, err)
 	}
 
-	slug, ok := r.Slug(code)
+	slug, ok := runtime.ExtractSlugFromComment(code)
 	if !ok {
 		return &unlinked{
 			path: cfg.file,

--- a/pkg/cmd/tasks/execute/execute.go
+++ b/pkg/cmd/tasks/execute/execute.go
@@ -227,17 +227,12 @@ func slugFromYaml(file string) (string, error) {
 
 // slugFromScript attempts to extract a slug from a script.
 func slugFromScript(file string) (string, error) {
-	r, ok := runtime.Lookup(file)
-	if !ok {
-		return "", fmt.Errorf("%s tasks are not supported", file)
-	}
-
 	code, err := ioutil.ReadFile(file)
 	if err != nil {
 		return "", fmt.Errorf("cannot read file %s - %w", file, err)
 	}
 
-	slug, ok := r.Slug(code)
+	slug, ok := runtime.ExtractSlugFromComment(code)
 	if !ok {
 		return "", fmt.Errorf("cannot find a slug in %s", file)
 	}

--- a/pkg/cmd/tasks/initcmd/init.go
+++ b/pkg/cmd/tasks/initcmd/init.go
@@ -86,7 +86,7 @@ func run(ctx context.Context, cfg config) error {
 			return err
 		}
 
-		if slug, ok := r.Slug(buf); ok && slug == task.Slug {
+		if slug, ok := runtime.ExtractSlugFromComment(buf); ok && slug == task.Slug {
 			logger.Log("%s is already linked to %s", cfg.file, cfg.slug)
 			suggestDeploy(cfg.file)
 			return nil
@@ -102,7 +102,7 @@ func run(ctx context.Context, cfg config) error {
 			return nil
 		}
 
-		code := []byte(r.Comment(task))
+		code := []byte(runtime.Comment(task))
 		code = append(code, '\n', '\n')
 		code = append(code, buf...)
 

--- a/pkg/runtime/comment.go
+++ b/pkg/runtime/comment.go
@@ -1,0 +1,41 @@
+package runtime
+
+import (
+	"net/url"
+	"path"
+	"regexp"
+
+	"github.com/airplanedev/cli/pkg/api"
+)
+
+var (
+	// commentRegex matches against the string produced by Comment() below.
+	//
+	// It is used to extract a slug from a comment in a script file.
+	commentRegex = regexp.MustCompile(`Linked to (https://.*air.*/t/.*) \[do not edit this line\]`)
+)
+
+// Comment generates a linking comment that is used
+// to associate a script file with an Airplane task.
+//
+// This comment can be parsed out of a script file using
+// ExtractSlugFromComment.
+func Comment(task api.Task) string {
+	return "Linked to " + task.URL + " [do not edit this line]"
+}
+
+func ExtractSlugFromComment(code []byte) (string, bool) {
+	result := commentRegex.FindSubmatch(code)
+	if len(result) == 0 {
+		return "", false
+	}
+
+	u, err := url.Parse(string(result[1]))
+	if err != nil {
+		return "", false
+	}
+
+	_, slug := path.Split(u.Path)
+
+	return slug, slug != ""
+}

--- a/pkg/runtime/comment_test.go
+++ b/pkg/runtime/comment_test.go
@@ -1,0 +1,69 @@
+package runtime
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestExtractSlugFromComment(tt *testing.T) {
+	for _, test := range []struct {
+		name string
+		in   string
+		slug string
+		ok   bool
+	}{
+		{
+			name: "empty file",
+			in:   ``,
+			ok:   false,
+		},
+		{
+			name: "missing comment",
+			in:   `import airplane from 'airplane'`,
+			ok:   false,
+		},
+		{
+			name: "unrelated comment",
+			in: `// Airplane (https://airplane.dev) is great!
+console.log('ship it')`,
+			ok: false,
+		},
+		{
+			name: "extracts slug correctly",
+			in: `// Linked to https://app.airplane.dev/t/myslug [do not edit this line]
+console.log('ship it')`,
+			slug: "myslug",
+			ok:   true,
+		},
+		{
+			name: "extracts slug correctly in staging",
+			in: `// Linked to https://web.airstage.app/t/myslug [do not edit this line]
+console.log('ship it')`,
+			slug: "myslug",
+			ok:   true,
+		},
+		{
+			name: "extracts slug correctly in dev",
+			in: `// Linked to https://app.airplane.so:5000/t/myslug [do not edit this line]
+console.log('ship it')`,
+			slug: "myslug",
+			ok:   true,
+		},
+		{
+			name: "extracts slug correctly regardless of line number",
+			in: `import airplane from 'airplane'
+console.log('ship it')
+
+// Linked to https://app.airplane.dev/t/myslug [do not edit this line]`,
+			slug: "myslug",
+			ok:   true,
+		},
+	} {
+		tt.Run(test.name, func(t *testing.T) {
+			slug, ok := ExtractSlugFromComment([]byte(test.in))
+			require.Equal(t, test.ok, ok)
+			require.Equal(t, test.slug, slug)
+		})
+	}
+}

--- a/pkg/runtime/javascript/javascript.go
+++ b/pkg/runtime/javascript/javascript.go
@@ -1,15 +1,11 @@
 package javascript
 
 import (
-	"bufio"
 	"bytes"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"net/url"
-	"path"
 	"path/filepath"
-	"strings"
 	"text/template"
 
 	"github.com/airplanedev/cli/pkg/api"
@@ -22,13 +18,8 @@ func init() {
 	runtime.Register(".js", Runtime{})
 }
 
-// CommentPrefix.
-const (
-	commentPrefix = "// Linked to Airplane task, do not edit:"
-)
-
 // Code template.
-var code = template.Must(template.New("js").Parse(`{{.Comment}}
+var code = template.Must(template.New("js").Parse(`// {{.Comment}}
 
 export default async function(params){
   console.log('parameters: ', params);
@@ -45,7 +36,7 @@ type Runtime struct{}
 
 // Generate implementation.
 func (r Runtime) Generate(t api.Task) ([]byte, error) {
-	var args = data{Comment: r.Comment(t)}
+	var args = data{Comment: runtime.Comment(t)}
 	var buf bytes.Buffer
 
 	if err := code.Execute(&buf, args); err != nil {
@@ -53,35 +44,6 @@ func (r Runtime) Generate(t api.Task) ([]byte, error) {
 	}
 
 	return buf.Bytes(), nil
-}
-
-// Slug implementation.
-func (r Runtime) Slug(code []byte) (string, bool) {
-	var s = bufio.NewScanner(bytes.NewReader(code))
-
-	for s.Scan() {
-		var line = strings.TrimSpace(s.Text())
-
-		if strings.HasPrefix(line, commentPrefix) {
-			continue
-		}
-
-		rawurl := strings.TrimSpace(strings.TrimPrefix(line, "//"))
-		u, err := url.Parse(rawurl)
-		if err != nil {
-			return "", false
-		}
-
-		_, slug := path.Split(u.Path)
-		return slug, len(slug) > 0
-	}
-
-	return "", false
-}
-
-// Comment implementation.
-func (r Runtime) Comment(t api.Task) string {
-	return fmt.Sprintf("%s\n// %s", commentPrefix, t.URL)
 }
 
 // Workdir implementation.

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -35,17 +35,6 @@ type Interface interface {
 	// An error is returned if the code cannot be generated.
 	Generate(task api.Task) ([]byte, error)
 
-	// Slug returns the slug from the given code.
-	//
-	// If the comment was not found in code, the method
-	// returns empty string and false.
-	Slug(code []byte) (string, bool)
-
-	// Comment returns a special airplane comment.
-	//
-	// The comment links a remote task to a file.
-	Comment(task api.Task) string
-
 	// Workdir attempts to detect the root of the given task path.
 	//
 	// Unlike root it decides the dockerfile's `workdir` directive

--- a/pkg/runtime/typescript/typescript.go
+++ b/pkg/runtime/typescript/typescript.go
@@ -48,7 +48,7 @@ type Runtime struct {
 
 // Generate implementation.
 func (r Runtime) Generate(t api.Task) ([]byte, error) {
-	var args = data{Comment: r.Comment(t)}
+	var args = data{Comment: runtime.Comment(t)}
 	var params = t.Parameters
 	var buf bytes.Buffer
 


### PR DESCRIPTION
This PR updates the comment we attach to JS files that links that file with an Airplane task to use the copy from: https://github.com/airplanedev/cli/pull/148#discussion_r647680710

While here, I also extracted the slug detection logic from the JS runtime and tweaked it to handle linking comments that are not on the first line of the script file. This should partially resolve: https://linear.app/airplane/issue/AIR-1228/detect-missing-slug-comment