### PR TITLE
Update GetKindAndOptions for REST: remove jsonBody, add bodyType

### DIFF
--- a/pkg/taskdir/definitions/def_0_2.go
+++ b/pkg/taskdir/definitions/def_0_2.go
@@ -73,8 +73,8 @@ type RESTDefinition struct {
 	Method    string            `yaml:"method" mapstructure:"method"`
 	Path      string            `yaml:"path" mapstructure:"path"`
 	URLParams map[string]string `yaml:"urlParams,omitempty" mapstructure:"urlParams"`
-	Body      string            `yaml:"body,omitempty" mapstructure:"body"`
-	JSONBody  interface{}       `yaml:"jsonBody,omitempty" mapstructure:"jsonBody"`
+	Body      string            `yaml:"body,omitempty" mapstructure:"body,omitempty"`
+	JSONBody  interface{}       `yaml:"jsonBody,omitempty" mapstructure:"jsonBody,omitempty"`
 }
 
 func (d Definition_0_2) upgrade() (Definition, error) {

--- a/pkg/taskdir/definitions/definitions.go
+++ b/pkg/taskdir/definitions/definitions.go
@@ -125,16 +125,27 @@ func (this Definition) GetKindAndOptions() (api.TaskKind, api.KindOptions, error
 		if err := mapstructure.Decode(this.REST, &options); err != nil {
 			return "", api.KindOptions{}, errors.Wrap(err, "decoding REST definition")
 		}
-		// API expects jsonBody to be a string, since it's handlebars-templated JSON and not always valid JSON. For
-		// convenience, we allow the YAML definition to be a structured object when the jsonBody is actually valid
-		// JSON. In that case, if it's not a string, we JSON-serialize it into a string.
-		if _, ok := options["jsonBody"].(string); !ok && options["jsonBody"] != nil {
-			jsonBody, err := json.Marshal(options["jsonBody"])
-			if err != nil {
-				return "", api.KindOptions{}, errors.Wrap(err, "marshalling JSON body")
+
+		// API expects a single body field to be a string. For convenience, we allow the YAML definition to be a
+		// structured object when the jsonBody is actually valid JSON. In that case, if it's not a string, we
+		// JSON-serialize it into a string.
+		// API also expects a bodyType key.
+		if options["jsonBody"] != nil {
+			if _, ok := options["jsonBody"].(string); !ok && options["jsonBody"] != nil {
+				jsonBody, err := json.Marshal(options["jsonBody"])
+				if err != nil {
+					return "", api.KindOptions{}, errors.Wrap(err, "marshalling JSON body")
+				}
+				options["body"] = string(jsonBody)
+			} else {
+				options["body"] = options["jsonBody"]
 			}
-			options["jsonBody"] = string(jsonBody)
+			options["bodyType"] = "json"
+			delete(options, "jsonBody")
+		} else {
+			options["bodyType"] = "raw"
 		}
+
 		return api.TaskKindREST, options, nil
 	}
 


### PR DESCRIPTION
Supports https://github.com/airplanedev/airport/pull/537.

We keep the separate `jsonBody`/`body` handling in the yaml because it makes sense to have structured `jsonBody` where possible. The data gets transformed before it hits the API server.