### PR TITLE
Bring back `--file/-f` flag to `deploy/execute` as a deprecated flag

### DIFF
--- a/pkg/cmd/root/usage.go
+++ b/pkg/cmd/root/usage.go
@@ -16,6 +16,11 @@ func usage(cmd *cobra.Command) error {
 
 // Help prints the help for a command.
 func help(cmd *cobra.Command, args []string) {
+	desc := cmd.Short
+	if cmd.Long != "" {
+		desc = cmd.Long
+	}
+	logger.Log("%s", desc)
 	logger.Log("")
 	logger.Log("%s", logger.Bold("Usage:"))
 	logger.Log("  %s", cmd.UseLine())

--- a/pkg/cmd/tasks/deploy/deploy.go
+++ b/pkg/cmd/tasks/deploy/deploy.go
@@ -49,7 +49,7 @@ func New(c *cli.Config) *cobra.Command {
 		}),
 	}
 
-	cmd.Flags().BoolVarP(&cfg.local, "local", "L", false, "use a local (instead of Airplane-hosted) Docker daemon")
+	cmd.Flags().BoolVarP(&cfg.local, "local", "L", false, "use a local Docker daemon (instead of an Airplane-hosted builder)")
 	cmd.Flags().StringVarP(&cfg.file, "file", "f", "", "File to deploy (.yaml, .yml, .js, .ts)")
 	cli.Must(cmd.Flags().MarkHidden("file")) // --file is deprecated
 

--- a/pkg/cmd/tasks/deploy/deploy.go
+++ b/pkg/cmd/tasks/deploy/deploy.go
@@ -8,7 +8,9 @@ import (
 	"github.com/airplanedev/cli/pkg/api"
 	"github.com/airplanedev/cli/pkg/cli"
 	"github.com/airplanedev/cli/pkg/cmd/auth/login"
+	"github.com/airplanedev/cli/pkg/logger"
 	"github.com/airplanedev/cli/pkg/utils"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -24,16 +26,22 @@ func New(c *cli.Config) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "deploy",
 		Short: "Deploy a task",
-		Long:  "Deploy a task from a YAML-based task definition",
+		Long:  "Deploy code from a local directory to Airplane.",
 		Example: heredoc.Doc(`
-			airplane tasks deploy my-task.yml
-			airplane tasks deploy task.ts
-			airplane tasks deploy task.js
-			airplane tasks deploy --local task.js
+			airplane tasks deploy ./task.ts
+			airplane tasks deploy --local ./task.js
+			airplane tasks deploy ./my-task.yml
 		`),
-		Args: cobra.ExactArgs(1),
+		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cfg.file = args[0]
+			if cfg.file != "" {
+				// A file was provided with the -f flag. This is deprecated.
+				logger.Warning(`The --file/-f flag is deprecated and will be removed in a future release. File paths should be passed as a positional argument instead: airplane deploy %s`, cfg.file)
+			} else if len(args) > 0 {
+				cfg.file = args[0]
+			} else {
+				return errors.New("expected 1 argument: airplane deploy ./path/to/file")
+			}
 			return run(cmd.Root().Context(), cfg)
 		},
 		PersistentPreRunE: utils.WithParentPersistentPreRunE(func(cmd *cobra.Command, args []string) error {
@@ -41,7 +49,9 @@ func New(c *cli.Config) *cobra.Command {
 		}),
 	}
 
-	cmd.Flags().BoolVarP(&cfg.local, "local", "L", false, "Add to build the docker image locally.")
+	cmd.Flags().BoolVarP(&cfg.local, "local", "L", false, "use a local (instead of Airplane-hosted) Docker daemon")
+	cmd.Flags().StringVarP(&cfg.file, "file", "f", "", "File to deploy (.yaml, .yml, .js, .ts)")
+	cli.Must(cmd.Flags().MarkHidden("file")) // --file is deprecated
 
 	return cmd
 }

--- a/pkg/cmd/tasks/execute/execute.go
+++ b/pkg/cmd/tasks/execute/execute.go
@@ -77,6 +77,10 @@ func run(ctx context.Context, cfg config) error {
 	task, err := client.GetTask(ctx, cfg.task)
 	if _, ok := err.(*api.TaskMissingError); ok {
 		// If there's no task matching that slug, try it as a file path instead.
+		if !fs.Exists(cfg.task) {
+			return errors.Errorf("Unable to execute %s. No matching file or task slug.", cfg.task)
+		}
+
 		slug, err := slugFrom(cfg.task)
 		if err != nil {
 			return err
@@ -207,10 +211,6 @@ func flagset(task api.Task, args api.Values) *flag.FlagSet {
 
 // SlugFrom returns the slug from the given file.
 func slugFrom(file string) (string, error) {
-	if !fs.Exists(file) {
-		return "", errors.Errorf("Unable to execute %s. No matching file or task slug.", file)
-	}
-
 	switch ext := filepath.Ext(file); ext {
 	case ".yml", ".yaml":
 		return slugFromYaml(file)

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -27,6 +27,11 @@ func Error(msg string, args ...interface{}) {
 	fmt.Fprintf(os.Stderr, Red("Error: ")+msg+"\n", args...)
 }
 
+// Warning logs a warning message.
+func Warning(msg string, args ...interface{}) {
+	fmt.Fprint(os.Stderr, Yellow("[warning] "+msg+"\n", args...))
+}
+
 // Debug writes a log message to stderr, followed by a newline, if the CLI
 // is executing in debug mode. Printf-style formatting is applied to msg
 // using args.


### PR DESCRIPTION
This PR brings back the `--file/-f` flag to the `deploy` and the `execute` commands. This was previously going to be a breaking change between `0.0.x` and `0.1.x`, but we want to reduce the incompatibility between these releases.

When used, it will log a warning message:

![image](https://user-images.githubusercontent.com/2907397/121256473-98cbf200-c87a-11eb-914b-07366632e962.png)

While here, I also fixed an issue with `execute`-ing slugs that match a local file. I also added the short/long command descriptions to our custom command help text.