### PR TITLE
Rewrite ignore logic using gitignore library

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/moby/sys/mount v0.2.0 // indirect
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/pkg/errors v0.9.1
+	github.com/sabhiram/go-gitignore v0.0.0-20201211210132-54b8a0bf510f
 	github.com/segmentio/events/v2 v2.4.0
 	github.com/spf13/cobra v1.1.3
 	github.com/stretchr/testify v1.6.1

--- a/go.sum
+++ b/go.sum
@@ -923,6 +923,8 @@ github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
 github.com/ryancurrah/gomodguard v1.0.4/go.mod h1:9T/Cfuxs5StfsocWr4WzDL36HqnX0fVb9d5fSEaLhoE=
 github.com/ryancurrah/gomodguard v1.1.0/go.mod h1:4O8tr7hBODaGE6VIhfJDHcwzh5GUccKSJBU0UMXJFVM=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
+github.com/sabhiram/go-gitignore v0.0.0-20201211210132-54b8a0bf510f h1:8P2MkG70G76gnZBOPGwmMIgwBb/rESQuwsJ7K8ds4NE=
+github.com/sabhiram/go-gitignore v0.0.0-20201211210132-54b8a0bf510f/go.mod h1:+ePHsJ1keEjQtpvf9HHw0f4ZeJ0TLRsxhunSI2hYJSs=
 github.com/safchain/ethtool v0.0.0-20190326074333-42ed695e3de8/go.mod h1:Z0q5wiBQGYcxhMZ6gUqHn6pYNLypFAvaL3UvgZLR0U4=
 github.com/sassoftware/go-rpmutils v0.0.0-20190420191620-a8f1baeba37b/go.mod h1:am+Fp8Bt506lA3Rk3QCmSqmYmLMnPDhdDUcosQCAx+I=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
@@ -1597,6 +1599,7 @@ rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.14/go.mod h1:LEScyzhFmoF5pso/YSeBstl57mOzx9xlU9n85RGrDQg=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=
+sigs.k8s.io/structured-merge-diff v1.0.1-0.20191108220359-b1b620dd3f06 h1:zD2IemQ4LmOcAumeiyDWXKUI2SO0NYDe3H6QGvPOVgU=
 sigs.k8s.io/structured-merge-diff v1.0.1-0.20191108220359-b1b620dd3f06/go.mod h1:/ULNhyfzRopfcjskuui0cTITekDduZ7ycKN3oUT9R18=
 sigs.k8s.io/structured-merge-diff/v4 v4.0.1/go.mod h1:bJZC9H9iH24zzfZ/41RGcq60oK1F7G282QMXDPYydCw=
 sigs.k8s.io/structured-merge-diff/v4 v4.0.2/go.mod h1:bJZC9H9iH24zzfZ/41RGcq60oK1F7G282QMXDPYydCw=

--- a/pkg/build/ignore/ignore.go
+++ b/pkg/build/ignore/ignore.go
@@ -1,0 +1,111 @@
+package ignore
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/airplanedev/cli/pkg/api"
+	"github.com/airplanedev/cli/pkg/logger"
+	"github.com/pkg/errors"
+	gitignore "github.com/sabhiram/go-gitignore"
+)
+
+// Returns an IgnoreFunc that can be used with airplanedev/archiver to filter
+// out files that match a default list or user-provided .airplaneignore.
+func GetIgnoreFunc(taskRootPath string, kind api.TaskKind) (func(filePath string, info os.FileInfo) (bool, error), error) {
+	excludes, err := getIgnorePatterns(taskRootPath)
+	if err != nil {
+		return nil, err
+	}
+	logger.Debug("Excludes:\n  %s", strings.Join(excludes, "\n  "))
+
+	ig := gitignore.CompileIgnoreLines(excludes...)
+	hasInclusion := false
+	for _, pat := range excludes {
+		if strings.HasPrefix(pat, "!") {
+			hasInclusion = true
+			break
+		}
+	}
+
+	return func(filePath string, info os.FileInfo) (bool, error) {
+		// Ignore symbolic links. For example, in Node projects you occasionally see
+		// symbolic links to binaries like `.bin/foobar`  which don't exist.
+		if info.Mode()&os.ModeSymlink == os.ModeSymlink {
+			return false, nil
+		}
+
+		relFilePath, err := filepath.Rel(taskRootPath, filePath)
+		if err != nil {
+			return false, errors.Wrap(err, "getting archive relative path")
+		}
+
+		skip := ig.MatchesPath(relFilePath)
+
+		// If we want to skip this file, and it's a directory, then we can skip it only if there
+		// are no inclusions.
+		// Ideally, we are smarter about this and skip the dir if there's no way for the inclusion
+		// pattern to match the dir. However, this is tricky with things like "!foo/" matching
+		// any directory named foo/ inside this directory.
+		if info.IsDir() && skip && !hasInclusion {
+			return false, nil
+		}
+
+		if !skip {
+			logger.Debug("Including in build archive: %s", relFilePath)
+		}
+		return !skip, nil
+	}, nil
+}
+
+func getIgnorePatterns(path string) ([]string, error) {
+	// Start with default set of excludes.
+	// We exclude the same files regardless of kind because you might have both JS and PY tasks and
+	// want pyc files excluded just the same.
+	// For inspiration, see:
+	// https://github.com/github/gitignore
+	// https://github.com/github/gitignore/blob/master/Go.gitignore
+	// https://github.com/github/gitignore/blob/master/Node.gitignore
+	excludes := []string{
+		"*.env",
+		"*.pyc",
+		".git",
+		".gitmodules",
+		".hg",
+		".next",
+		".now",
+		".npm",
+		".svn",
+		".venv",
+		".yarn",
+		"__pycache__",
+		"bin",
+		"dist",
+		"node_modules",
+		"npm-debug.log",
+		"out",
+	}
+
+	// Allow user-specified ignore file. Note that users can re-INCLUDE files using !, so if our
+	// default excludes skip something necessary they can always add it back.
+	const ignorefile = ".airplaneignore"
+	bs, err := ioutil.ReadFile(filepath.Join(path, ignorefile))
+	switch {
+	case os.IsNotExist(err):
+		// Nothing additional to append
+		return excludes, nil
+	case err != nil:
+		return nil, err
+	}
+	fileExcludes := []string{}
+	for _, ex := range strings.Split(string(bs), "\n") {
+		if ex != "" {
+			fileExcludes = append(fileExcludes, ex)
+		}
+	}
+	logger.Debug("Found %s - using %d exclude rule(s):\n  %s", ignorefile, len(fileExcludes), strings.Join(fileExcludes, "\n  "))
+	excludes = append(excludes, fileExcludes...)
+	return excludes, nil
+}

--- a/pkg/build/ignore/ignore.go
+++ b/pkg/build/ignore/ignore.go
@@ -6,7 +6,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/airplanedev/cli/pkg/api"
 	"github.com/airplanedev/cli/pkg/logger"
 	"github.com/pkg/errors"
 	gitignore "github.com/sabhiram/go-gitignore"
@@ -14,7 +13,7 @@ import (
 
 // Returns an IgnoreFunc that can be used with airplanedev/archiver to filter
 // out files that match a default list or user-provided .airplaneignore.
-func GetIgnoreFunc(taskRootPath string, kind api.TaskKind) (func(filePath string, info os.FileInfo) (bool, error), error) {
+func GetIgnoreFunc(taskRootPath string) (func(filePath string, info os.FileInfo) (bool, error), error) {
 	excludes, err := getIgnorePatterns(taskRootPath)
 	if err != nil {
 		return nil, err

--- a/pkg/build/remote.go
+++ b/pkg/build/remote.go
@@ -80,14 +80,9 @@ func archiveTaskDir(def definitions.Definition, root string, archivePath string)
 		}
 	}
 
+	var err error
 	arch := archiver.NewTarGz()
-
-	kind, _, err := def.GetKindAndOptions()
-	if err != nil {
-		return err
-	}
-
-	arch.Tar.IncludeFunc, err = ignore.GetIgnoreFunc(root, kind)
+	arch.Tar.IncludeFunc, err = ignore.GetIgnoreFunc(root)
 	if err != nil {
 		return err
 	}
@@ -96,8 +91,7 @@ func archiveTaskDir(def definitions.Definition, root string, archivePath string)
 		return errors.Wrap(err, "building archive")
 	}
 
-	// return nil
-	return errors.New("DEBUG")
+	return nil
 }
 
 func uploadArchive(ctx context.Context, client *api.Client, archivePath string) (string, error) {

--- a/pkg/build/remote.go
+++ b/pkg/build/remote.go
@@ -7,17 +7,15 @@ import (
 	"net/http"
 	"os"
 	"path"
-	"path/filepath"
 	"strings"
 	"time"
 
 	"github.com/airplanedev/archiver"
 	"github.com/airplanedev/cli/pkg/api"
+	"github.com/airplanedev/cli/pkg/build/ignore"
 	"github.com/airplanedev/cli/pkg/logger"
 	"github.com/airplanedev/cli/pkg/taskdir/definitions"
-	dockerFileUtils "github.com/docker/docker/pkg/fileutils"
 	"github.com/dustin/go-humanize"
-	"github.com/moby/buildkit/frontend/dockerfile/dockerignore"
 	"github.com/pkg/errors"
 )
 
@@ -89,7 +87,7 @@ func archiveTaskDir(def definitions.Definition, root string, archivePath string)
 		return err
 	}
 
-	arch.Tar.IncludeFunc, err = getIgnoreFunc(root, kind)
+	arch.Tar.IncludeFunc, err = ignore.GetIgnoreFunc(root, kind)
 	if err != nil {
 		return err
 	}
@@ -98,131 +96,8 @@ func archiveTaskDir(def definitions.Definition, root string, archivePath string)
 		return errors.Wrap(err, "building archive")
 	}
 
-	return nil
-}
-
-// Returns an IgnoreFunc that can be used with airplanedev/archiver to filter
-// out files that match a default (or user-provided) .dockerignore.
-//
-// This is modeled off of docker/cli.
-// See: https://github.com/docker/cli/blob/a32cd16160f1b41c1c4ae7bee4dac929d1484e59/vendor/github.com/docker/docker/pkg/archive/archive.go#L738
-func getIgnoreFunc(taskRootPath string, kind api.TaskKind) (func(filePath string, info os.FileInfo) (bool, error), error) {
-	excludes, err := getIgnorePatterns(taskRootPath)
-	if err != nil {
-		return nil, err
-	}
-
-	pm, err := dockerFileUtils.NewPatternMatcher(excludes)
-	if err != nil {
-		return nil, errors.Wrap(err, "parsing dockerignore patterns")
-	}
-
-	return func(filePath string, info os.FileInfo) (bool, error) {
-		// Ignore symbolic links. For example, in Node projects you occasionally see
-		// symbolic links to binaries like `.bin/foobar`  which don't exist.
-		if info.Mode()&os.ModeSymlink == os.ModeSymlink {
-			return false, nil
-		}
-
-		relFilePath, err := filepath.Rel(taskRootPath, filePath)
-		if err != nil {
-			return false, errors.Wrap(err, "getting archive relative path")
-		}
-
-		skip, err := pm.Matches(relFilePath)
-		if err != nil {
-			return false, errors.Wrap(err, "matching file")
-		}
-
-		// If we want to skip this file and it's a directory
-		// then we should first check to see if there's an
-		// inclusion pattern (e.g. !dir/file) that starts with this
-		// dir. If so then we can't skip this dir.
-		if info.IsDir() && skip {
-			for _, pat := range pm.Patterns() {
-				if !pat.Exclusion() {
-					continue
-				}
-				if strings.HasPrefix(pat.String()+string(filepath.Separator), relFilePath+string(filepath.Separator)) {
-					// There is a pattern in this directory that should be included, so
-					// we can't skip this directory.
-					logger.Debug("Including in build archive: %s", relFilePath)
-					return true, nil
-				}
-			}
-
-			return false, nil
-		}
-
-		if !skip {
-			logger.Debug("Including in build archive: %s", relFilePath)
-		}
-		return !skip, nil
-	}, nil
-}
-
-// readIgnorefile reads a .dockerignore-like file
-// Based off of github.com/docker/cli@v20.10.6/cli/command/image/build/dockerignore.go
-// Reference: https://docs.docker.com/engine/reference/builder/#dockerignore-file
-func readIgnorefile(contextDir, filename string) ([]string, error) {
-	var excludes []string
-
-	f, err := os.Open(filepath.Join(contextDir, filename))
-	switch {
-	case os.IsNotExist(err):
-		return excludes, nil
-	case err != nil:
-		return nil, err
-	}
-	defer f.Close()
-
-	return dockerignore.ReadAll(f)
-}
-
-func getIgnorePatterns(path string) ([]string, error) {
-	// Start with default set of excludes.
-	// We exclude the same files regardless of kind because you might have both JS and PY tasks and
-	// want pyc files excluded just the same.
-	// For inspiration, see:
-	// https://github.com/github/gitignore
-	// https://github.com/github/gitignore/blob/master/Go.gitignore
-	// https://github.com/github/gitignore/blob/master/Node.gitignore
-	excludes := []string{
-		"**/*.env",
-		"**/*.pyc",
-		"**/.next",
-		"**/.now",
-		"**/.npm",
-		"**/.venv",
-		"**/.yarn",
-		"**/__pycache__",
-		"**/bin",
-		"**/dist",
-		"**/node_modules",
-		"**/npm-debug.log",
-		"**/out",
-		".git",
-		".gitmodules",
-		".hg",
-		".svn",
-	}
-
-	// Allow user-specified ignore file. Note that users can re-INCLUDE files using !, so if our
-	// default excludes skip something necessary they can always add it back.
-
-	// Prefer .airplaneignore over .dockerignore
-	for _, ignorefile := range []string{".airplaneignore", ".dockerignore"} {
-		ex, err := readIgnorefile(path, ignorefile)
-		if err != nil {
-			return nil, errors.Wrapf(err, "reading %s", ignorefile)
-		}
-		if len(ex) > 0 {
-			logger.Debug("Found %s - using %d exclude rule(s)", ignorefile, len(ex))
-			excludes = append(excludes, ex...)
-			return excludes, nil
-		}
-	}
-	return excludes, nil
+	// return nil
+	return errors.New("DEBUG")
 }
 
 func uploadArchive(ctx context.Context, client *api.Client, archivePath string) (string, error) {


### PR DESCRIPTION
Drops support for .dockerignore for now, although we may re-add support
for that with dockerfile support

Replaces with (1) default ignores like before, but in gitignore-syntax
and (2) support for .airplaneignore like before, but in
gitignore-syntax.
