### PR TITLE
Set shim=true on scripts deploy

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -387,6 +387,7 @@ type CreateBuildRequest struct {
 	TaskID         string  `json:"taskID"`
 	SourceUploadID string  `json:"sourceUploadID"`
 	Env            TaskEnv `json:"env"`
+	Shim           bool    `json:"shim"`
 }
 
 type CreateBuildResponse struct {

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -15,6 +15,7 @@ type Request struct {
 	Def     definitions.Definition
 	TaskID  string
 	TaskEnv api.TaskEnv
+	Shim    bool
 }
 
 // Response represents a build response.

--- a/pkg/build/local.go
+++ b/pkg/build/local.go
@@ -25,7 +25,9 @@ func local(ctx context.Context, req Request) (*Response, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	args := make(map[string]string, len(options))
+
 	for k, v := range options {
 		if sv, ok := v.(string); !ok {
 			return nil, errors.New("unexpected non-string option for builder arg")
@@ -33,6 +35,11 @@ func local(ctx context.Context, req Request) (*Response, error) {
 			args[k] = sv
 		}
 	}
+
+	if req.Shim {
+		args["shim"] = "true"
+	}
+
 	b, err := New(LocalConfig{
 		Root:    req.Root,
 		Builder: string(kind),

--- a/pkg/build/remote.go
+++ b/pkg/build/remote.go
@@ -47,6 +47,7 @@ func remote(ctx context.Context, req Request) (*Response, error) {
 		TaskID:         req.TaskID,
 		SourceUploadID: uploadID,
 		Env:            req.TaskEnv,
+		Shim:           req.Shim,
 	})
 	if err != nil {
 		return nil, errors.Wrap(err, "creating build")

--- a/pkg/cmd/tasks/deploy/script.go
+++ b/pkg/cmd/tasks/deploy/script.go
@@ -113,6 +113,7 @@ func deployFromScript(ctx context.Context, cfg config) error {
 		Root:    taskroot,
 		Def:     def,
 		TaskEnv: def.Env,
+		Shim:    true,
 	})
 	if err != nil {
 		return err

--- a/pkg/taskdir/definitions/definitions.go
+++ b/pkg/taskdir/definitions/definitions.go
@@ -105,11 +105,6 @@ func (this Definition) GetKindAndOptions() (api.TaskKind, api.KindOptions, error
 		if err := mapstructure.Decode(this.Node, &options); err != nil {
 			return "", api.KindOptions{}, errors.Wrap(err, "decoding Node definition")
 		}
-		// Node tasks built with older versions of the CLI will have `shim=false` which
-		// instructs the remote builder to build Node tasks using the old (non-shim) version.
-		//
-		// We can remove this after we roll out this new JS task syntax to our existing users.
-		options["shim"] = "true"
 		return api.TaskKindNode, options, nil
 	} else if this.Python != nil {
 		if err := mapstructure.Decode(this.Python, &options); err != nil {


### PR DESCRIPTION
That way we do not override yaml config and use a shim there
also adds shim=true to all runtimes.
