### PR TITLE
Tweak shim toggle behavior

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -387,7 +387,6 @@ type CreateBuildRequest struct {
 	TaskID         string  `json:"taskID"`
 	SourceUploadID string  `json:"sourceUploadID"`
 	Env            TaskEnv `json:"env"`
-	Shim           bool    `json:"shim"`
 }
 
 type CreateBuildResponse struct {

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -15,7 +15,6 @@ type Request struct {
 	Def     definitions.Definition
 	TaskID  string
 	TaskEnv api.TaskEnv
-	Shim    bool
 }
 
 // Response represents a build response.

--- a/pkg/build/local.go
+++ b/pkg/build/local.go
@@ -36,10 +36,6 @@ func local(ctx context.Context, req Request) (*Response, error) {
 		}
 	}
 
-	if req.Shim {
-		args["shim"] = "true"
-	}
-
 	b, err := New(LocalConfig{
 		Root:    req.Root,
 		Builder: string(kind),

--- a/pkg/build/remote.go
+++ b/pkg/build/remote.go
@@ -47,7 +47,6 @@ func remote(ctx context.Context, req Request) (*Response, error) {
 		TaskID:         req.TaskID,
 		SourceUploadID: uploadID,
 		Env:            req.TaskEnv,
-		Shim:           req.Shim,
 	})
 	if err != nil {
 		return nil, errors.Wrap(err, "creating build")

--- a/pkg/cmd/tasks/deploy/script.go
+++ b/pkg/cmd/tasks/deploy/script.go
@@ -81,6 +81,8 @@ func deployFromScript(ctx context.Context, cfg config) error {
 		return err
 	}
 
+	kindOptions["shim"] = "true"
+
 	// Before performing a remote build, we must first update kind/kindOptions
 	// since the remote build relies on pulling those from the tasks table (for now).
 	_, err = client.UpdateTask(ctx, api.UpdateTaskRequest{
@@ -113,7 +115,6 @@ func deployFromScript(ctx context.Context, cfg config) error {
 		Root:    taskroot,
 		Def:     def,
 		TaskEnv: def.Env,
-		Shim:    true,
 	})
 	if err != nil {
 		return err

--- a/pkg/cmd/tasks/deploy/script.go
+++ b/pkg/cmd/tasks/deploy/script.go
@@ -81,6 +81,8 @@ func deployFromScript(ctx context.Context, cfg config) error {
 		return err
 	}
 
+	// Instruct the remote builder API to perform a shim-based build since
+	// we're deploying from a script.
 	kindOptions["shim"] = "true"
 
 	// Before performing a remote build, we must first update kind/kindOptions


### PR DESCRIPTION
This is a follow-up to: https://github.com/airplanedev/cli/pull/166

Previously, we would pass a boolean to the remote build API, but this approach avoids API changes.