### PR TITLE
Add python runtime

### DIFF
--- a/pkg/build/python.go
+++ b/pkg/build/python.go
@@ -1,19 +1,88 @@
 package build
 
 import (
+	_ "embed"
 	"path/filepath"
 	"strings"
 	"text/template"
 
 	"github.com/airplanedev/cli/pkg/api"
 	"github.com/airplanedev/cli/pkg/fsx"
+	"github.com/pkg/errors"
 )
 
+// Python shim code.
+//go:embed shim.py
+var pythonShim string
+
 // Python creates a dockerfile for Python.
-func python(root string, options api.KindOptions) (string, error) {
-	entrypoint, _ := options["entrypoint"].(string)
+func python(root string, args api.KindOptions) (string, error) {
+	entrypoint, _ := args["entrypoint"].(string)
 	main := filepath.Join(root, entrypoint)
+	init := filepath.Join(root, "__init__.py")
 	reqs := filepath.Join(root, "requirements.txt")
+
+	if args["shim"] != "true" {
+		return pythonLegacy(root, args)
+	}
+
+	if err := fsx.AssertExistsAll(main); err != nil {
+		return "", err
+	}
+
+	v, err := GetVersion(NamePython, "3")
+	if err != nil {
+		return "", err
+	}
+
+	shim, err := applyTemplate(pythonShim, struct {
+		Entrypoint string
+	}{
+		Entrypoint: filepath.Join("/airplane", entrypoint),
+	})
+	if err != nil {
+		return "", errors.Wrapf(err, "rendering shim")
+	}
+
+	const dockerfile = `
+    FROM {{ .Base }}
+    WORKDIR /airplane
+    RUN echo '{{.Shim}}' > /shim.py
+    {{if not .HasInit}}
+    RUN touch __init__.py
+    {{end}}
+    COPY . .
+		{{if .HasRequirements}}
+    RUN pip install -r requirements.txt
+		{{end}}
+    ENTRYPOINT ["python", "/shim.py", "/airplane/{{ .Entrypoint }}"]
+	`
+
+	df, err := applyTemplate(dockerfile, struct {
+		Base            string
+		Shim            string
+		Entrypoint      string
+		HasRequirements bool
+		HasInit         bool
+	}{
+		Base:            v.String(),
+		Shim:            strings.Join(strings.Split(shim, "\n"), "\\n\\\n"),
+		Entrypoint:      entrypoint,
+		HasRequirements: fsx.Exists(reqs),
+		HasInit:         fsx.Exists(init),
+	})
+	if err != nil {
+		return "", errors.Wrapf(err, "rendering dockerfile")
+	}
+
+	return df, nil
+}
+
+// PythonLegacy generates a dockerfile for legacy python support.
+func pythonLegacy(root string, args api.KindOptions) (string, error) {
+	var entrypoint, _ = args["entrypoint"].(string)
+	var main = filepath.Join(root, entrypoint)
+	var reqs = filepath.Join(root, "requirements.txt")
 
 	if err := fsx.AssertExistsAll(main); err != nil {
 		return "", err

--- a/pkg/build/shim.py
+++ b/pkg/build/shim.py
@@ -1,0 +1,22 @@
+# This file includes a shim that will execute your task code.
+
+import importlib.util as util
+import json
+import sys
+import os
+
+def run(args):
+	if len(args) != 3:
+		raise Exception("shim: expected 3 arguments, got {}".format(args))
+
+	spec = util.spec_from_file_location("mod.main", "{{ .Entrypoint }}")
+	mod = util.module_from_spec(spec)
+	spec.loader.exec_module(mod)
+
+	try:
+		mod.main(json.loads(args[2]))
+	except Exception as e:
+		raise Exception("shim: executing {{.Entrypoint}}") from e
+
+if __name__ == "__main__":
+	run(sys.argv)

--- a/pkg/cmd/tasks/initcmd/init.go
+++ b/pkg/cmd/tasks/initcmd/init.go
@@ -20,6 +20,7 @@ import (
 	"github.com/airplanedev/cli/pkg/logger"
 	"github.com/airplanedev/cli/pkg/runtime"
 	_ "github.com/airplanedev/cli/pkg/runtime/javascript"
+	_ "github.com/airplanedev/cli/pkg/runtime/python"
 	_ "github.com/airplanedev/cli/pkg/runtime/typescript"
 	"github.com/airplanedev/cli/pkg/utils"
 	"github.com/spf13/cobra"

--- a/pkg/runtime/comment.go
+++ b/pkg/runtime/comment.go
@@ -24,20 +24,23 @@ func Comment(r Interface, task api.Task) string {
 	return r.FormatComment("Linked to " + task.URL + " [do not edit this line]")
 }
 
-func Slug(code []byte) (string, bool) {
+// Slug returns the slug from the given code.
+//
+// Ok is true if the slug was found and isn't empty.
+func Slug(code []byte) (slug string, ok bool) {
 	result := commentRegex.FindSubmatch(code)
 	if len(result) == 0 {
-		return "", false
+		return
 	}
 
 	u, err := url.Parse(string(result[1]))
 	if err != nil {
-		return "", false
+		return
 	}
 
-	_, slug := path.Split(u.Path)
-
-	return slug, slug != ""
+	_, slug = path.Split(u.Path)
+	ok = slug != ""
+	return
 }
 
 // ErrNotLinked is an error that is raised when a path unexpectedly

--- a/pkg/runtime/python/python.go
+++ b/pkg/runtime/python/python.go
@@ -1,0 +1,75 @@
+package python
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"html/template"
+	"strings"
+
+	"github.com/airplanedev/cli/pkg/api"
+	"github.com/airplanedev/cli/pkg/runtime"
+)
+
+// Init register the runtime.
+func init() {
+	runtime.Register(".py", Runtime{})
+}
+
+// Code template.
+var code = template.Must(template.New("py").Parse(`# {{.Comment}}
+
+def main(params):
+  print('parameters: ', params);
+`))
+
+// Data represents the data template.
+type data struct {
+	Comment string
+}
+
+// Runtime implementation.
+type Runtime struct{}
+
+// PrepareRun implementation.
+func (r Runtime) PrepareRun(ctx context.Context, opts runtime.PrepareRunOptions) ([]string, error) {
+	return nil, runtime.ErrNotImplemented
+}
+
+// Generate implementation.
+func (r Runtime) Generate(t api.Task) ([]byte, error) {
+	var args = data{Comment: runtime.Comment(r, t)}
+	var buf bytes.Buffer
+
+	if err := code.Execute(&buf, args); err != nil {
+		return nil, fmt.Errorf("javascript: template execute - %w", err)
+	}
+
+	return buf.Bytes(), nil
+}
+
+// Workdir implementation.
+func (r Runtime) Workdir(path string) (string, error) {
+	return r.Root(path)
+}
+
+// Root implementation.
+func (r Runtime) Root(path string) (string, error) {
+	return runtime.Pathof(path, "requirements.txt")
+}
+
+// Kind implementation.
+func (r Runtime) Kind() api.TaskKind {
+	return api.TaskKindPython
+}
+
+// FormatComment implementation.
+func (r Runtime) FormatComment(s string) string {
+	var lines []string
+
+	for _, line := range strings.Split(s, "\n") {
+		lines = append(lines, "# "+line)
+	}
+
+	return strings.Join(lines, "\n")
+}

--- a/pkg/runtime/python/python.go
+++ b/pkg/runtime/python/python.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/airplanedev/cli/pkg/api"
+	"github.com/airplanedev/cli/pkg/fsx"
 	"github.com/airplanedev/cli/pkg/runtime"
 )
 
@@ -55,7 +56,11 @@ func (r Runtime) Workdir(path string) (string, error) {
 
 // Root implementation.
 func (r Runtime) Root(path string) (string, error) {
-	return runtime.Pathof(path, "requirements.txt")
+	root, ok := fsx.Find(path, "requirements.txt")
+	if !ok {
+		return "", fmt.Errorf("cannot find requirements.txt")
+	}
+	return root, nil
 }
 
 // Kind implementation.

--- a/pkg/runtime/python/python.go
+++ b/pkg/runtime/python/python.go
@@ -17,7 +17,7 @@ func init() {
 }
 
 // Code template.
-var code = template.Must(template.New("py").Parse(`# {{.Comment}}
+var code = template.Must(template.New("py").Parse(`{{.Comment}}
 
 def main(params):
   print('parameters: ', params);

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -9,10 +9,24 @@ package runtime
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"path/filepath"
 
 	"github.com/airplanedev/cli/pkg/api"
+)
+
+var (
+	// ErrMissing is returned when a resource was not found.
+	//
+	// It can be checked via `errors.Is(err, ErrMissing)`.
+	ErrMissing = errors.New("runtime: resource is missing")
+
+	// ErrNotImplemented is returned when a runtime does not
+	// support preparing a run.
+	//
+	// It can be checked via `errors.Is(err, ErrNotImplemented)`.
+	ErrNotImplemented = errors.New("runtime: not implemented")
 )
 
 // Settings represent Airplane specific settings.
@@ -50,7 +64,16 @@ type Interface interface {
 	// the relevant comment characters for this runtime.
 	FormatComment(s string) string
 
-	// PrepareRun should prepare the
+	// PrepareRun should prepare a local run of a task.
+	//
+	// It must create a temporary directory, install any dependencies
+	// and prepare the script to be run.
+	//
+	// On success the method returns a slice that represents an `cmd.Exec`
+	// options which contains the command to be run and its arguments.
+	//
+	// If running the script locally is not supported the method returns
+	// an `ErrNotImplemented`.
 	PrepareRun(ctx context.Context, opts PrepareRunOptions) ([]string, error)
 }
 

--- a/pkg/taskdir/definitions/definitions.go
+++ b/pkg/taskdir/definitions/definitions.go
@@ -73,7 +73,7 @@ func NewDefinitionFromTask(task api.Task) (Definition, error) {
 		return Definition{}, errors.Errorf("unknown kind specified: %s", task.Kind)
 	}
 
-	if taskDef != nil {
+	if taskDef != nil && task.KindOptions != nil {
 		if err := mapstructure.Decode(task.KindOptions, taskDef); err != nil {
 			return Definition{}, errors.Wrap(err, "decoding options")
 		}


### PR DESCRIPTION
Initial implementation of Python runtime, it's inspired by the simplicity
of the node.js shim.

Note that the shim is python3.5+ because of module loading, i don't think
it's a big issue because it matches our image version. We can iterate on
this later and add python 2 support if needed.
