### PR TITLE
Fix missing comment chars when `init`-ing existing file

### DIFF
--- a/pkg/cmd/tasks/initcmd/init.go
+++ b/pkg/cmd/tasks/initcmd/init.go
@@ -102,7 +102,7 @@ func run(ctx context.Context, cfg config) error {
 			return nil
 		}
 
-		code := []byte(runtime.Comment(task))
+		code := []byte(runtime.Comment(r, task))
 		code = append(code, '\n', '\n')
 		code = append(code, buf...)
 

--- a/pkg/runtime/comment.go
+++ b/pkg/runtime/comment.go
@@ -19,8 +19,8 @@ var (
 // to associate a script file with an Airplane task.
 //
 // This comment can be parsed out of a script file using Slug.
-func Comment(task api.Task) string {
-	return "Linked to " + task.URL + " [do not edit this line]"
+func Comment(r Interface, task api.Task) string {
+	return r.FormatComment("Linked to " + task.URL + " [do not edit this line]")
 }
 
 func Slug(code []byte) (string, bool) {

--- a/pkg/runtime/javascript/javascript.go
+++ b/pkg/runtime/javascript/javascript.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"path/filepath"
+	"strings"
 	"text/template"
 
 	"github.com/airplanedev/cli/pkg/api"
@@ -19,9 +20,9 @@ func init() {
 }
 
 // Code template.
-var code = template.Must(template.New("js").Parse(`// {{.Comment}}
+var code = template.Must(template.New("js").Parse(`{{.Comment}}
 
-export default async function(params){
+export default async function(params) {
   console.log('parameters:', params);
 }
 `))
@@ -36,7 +37,7 @@ type Runtime struct{}
 
 // Generate implementation.
 func (r Runtime) Generate(t api.Task) ([]byte, error) {
-	var args = data{Comment: runtime.Comment(t)}
+	var args = data{Comment: runtime.Comment(r, t)}
 	var buf bytes.Buffer
 
 	if err := code.Execute(&buf, args); err != nil {
@@ -85,4 +86,12 @@ func (r Runtime) Root(path string) (string, error) {
 // Kind implementation.
 func (r Runtime) Kind() api.TaskKind {
 	return api.TaskKindNode
+}
+
+func (r Runtime) FormatComment(s string) string {
+	lines := []string{}
+	for _, line := range strings.Split(s, "\n") {
+		lines = append(lines, "// "+line)
+	}
+	return strings.Join(lines, "\n")
 }

--- a/pkg/runtime/javascript/javascript_test.go
+++ b/pkg/runtime/javascript/javascript_test.go
@@ -1,0 +1,18 @@
+package javascript
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFormatComment(t *testing.T) {
+	require := require.New(t)
+
+	r := Runtime{}
+
+	require.Equal("// test", r.FormatComment("test"))
+	require.Equal(`// line 1
+// line 2`, r.FormatComment(`line 1
+line 2`))
+}

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -56,6 +56,10 @@ type Interface interface {
 	// Generate and other methods should not be called
 	// for a task that doesn't match the returned kind.
 	Kind() api.TaskKind
+
+	// FormatComment formats a string into a comment using
+	// the relevant comment characters for this runtime.
+	FormatComment(s string) string
 }
 
 // Runtimes is a collection of registered runtimes.

--- a/pkg/runtime/typescript/typescript.go
+++ b/pkg/runtime/typescript/typescript.go
@@ -24,7 +24,7 @@ type Params = {
   {{- end }}
 }
 
-export default async function(params: Params){
+export default async function(params: Params) {
   console.log('parameters:', params);
 }
 `))
@@ -48,7 +48,7 @@ type Runtime struct {
 
 // Generate implementation.
 func (r Runtime) Generate(t api.Task) ([]byte, error) {
-	var args = data{Comment: runtime.Comment(t)}
+	var args = data{Comment: runtime.Comment(r, t)}
 	var params = t.Parameters
 	var buf bytes.Buffer
 


### PR DESCRIPTION
If you had an existing file and you ran `airplane init --slug ... ./file.js`, then it would create a file like so:

```js
// ⬇️ missing comment chars
Linked to https://...

export default async function(params) {
  // ...
}
```