### PR TITLE
Fix unable to find `package.json` in parent directories

### DIFF
--- a/pkg/cmd/tasks/dev/dev.go
+++ b/pkg/cmd/tasks/dev/dev.go
@@ -92,8 +92,13 @@ func run(ctx context.Context, cfg config) error {
 	logger.Log("Locally running %s task %s", logger.Bold(task.Name), logger.Gray("("+cfg.root.Client.TaskURL(task.Slug)+")"))
 	logger.Log("")
 
+	path, err := filepath.Abs(cfg.file)
+	if err != nil {
+		return errors.Wrapf(err, "absolute path of %s", cfg.file)
+	}
+
 	cmds, err := r.PrepareRun(ctx, runtime.PrepareRunOptions{
-		Path:        cfg.file,
+		Path:        path,
 		ParamValues: paramValues,
 		KindOptions: task.KindOptions,
 	})


### PR DESCRIPTION
This worked if you were running `airplane dev ./outputs/main.ts` where it finds `outputs/package.json`. It didn't work for `airplane dev ./main.ts`.