### PR TITLE
Handle >64KB log lines from `airplane dev`

### DIFF
--- a/pkg/cmd/tasks/dev/dev.go
+++ b/pkg/cmd/tasks/dev/dev.go
@@ -1,7 +1,6 @@
 package dev
 
 import (
-	"bufio"
 	"context"
 	"flag"
 	"fmt"
@@ -24,6 +23,7 @@ import (
 	"github.com/airplanedev/cli/pkg/print"
 	"github.com/airplanedev/cli/pkg/runtime"
 	"github.com/airplanedev/cli/pkg/utils"
+	"github.com/airplanedev/cli/pkg/utils/bufiox"
 	"github.com/joho/godotenv"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -141,7 +141,7 @@ func run(ctx context.Context, cfg config) error {
 	o := api.Outputs{}
 
 	logParser := func(r io.Reader) error {
-		scanner := bufio.NewScanner(r)
+		scanner := bufiox.NewScanner(r)
 		for scanner.Scan() {
 			line := scanner.Text()
 			if outputs.IsOutput(line) {

--- a/pkg/utils/bufiox/scanner.go
+++ b/pkg/utils/bufiox/scanner.go
@@ -1,0 +1,56 @@
+package bufiox
+
+import (
+	"bufio"
+	"io"
+)
+
+const bufferSizeBytes = 64 * 1024
+
+// Scanner is a drop-in replacement for bufio.Scanner that will
+// handle log lines that are longer than the default limit in
+// bufio (64KB).
+type Scanner struct {
+	r     *bufio.Reader
+	token []byte
+
+	err error
+}
+
+func NewScanner(r io.Reader) *Scanner {
+	return &Scanner{
+		r: bufio.NewReaderSize(r, bufferSizeBytes),
+	}
+}
+
+func (s *Scanner) Scan() bool {
+	// Clear the in-memory token buffer, but retain its allocated memory.
+	s.token = s.token[:0]
+
+	for done := false; !done; {
+		line, isPrefix, err := s.r.ReadLine()
+		if err != nil {
+			if err != io.EOF {
+				s.err = err
+			}
+			return false
+		}
+		s.token = append(s.token, line...)
+
+		done = !isPrefix
+	}
+
+	return false
+}
+
+func (s *Scanner) Bytes() []byte {
+	return s.token
+}
+
+func (s *Scanner) Text() string {
+	return string(s.token)
+}
+
+func (s *Scanner) Err() error {
+	return s.err
+}

--- a/pkg/utils/bufiox/scanner.go
+++ b/pkg/utils/bufiox/scanner.go
@@ -40,7 +40,7 @@ func (s *Scanner) Scan() bool {
 		done = !isPrefix
 	}
 
-	return false
+	return true
 }
 
 func (s *Scanner) Bytes() []byte {

--- a/pkg/utils/bufiox/scanner_test.go
+++ b/pkg/utils/bufiox/scanner_test.go
@@ -1,0 +1,68 @@
+package bufiox
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestScannerShortString(t *testing.T) {
+	require := require.New(t)
+
+	scanner := NewScanner(strings.NewReader(`a short string
+followed by another short string`))
+
+	// Does not start with an error.
+	require.NoError(scanner.Err())
+
+	// Reads the first line.
+	require.True(scanner.Scan())
+	require.Equal([]byte("a short string"), scanner.Bytes())
+	require.Equal("a short string", scanner.Text())
+	require.NoError(scanner.Err())
+
+	// Reads the second line.
+	require.True(scanner.Scan())
+	require.Equal([]byte("followed by another short string"), scanner.Bytes())
+	require.Equal("followed by another short string", scanner.Text())
+	require.NoError(scanner.Err())
+
+	// Finishes without error.
+	require.False(scanner.Scan())
+	require.NoError(scanner.Err())
+}
+
+func TestScannerLongString(t *testing.T) {
+	require := require.New(t)
+
+	// Generate some long strings for testing that
+	// require multiple buffers to read.
+	var str1 string
+	var str2 string
+	for len(str1) < bufferSizeBytes*2+bufferSizeBytes/2 {
+		str1 += "aaaaaaaaaa"
+		str2 += "bbbbbbbbbb"
+	}
+
+	scanner := NewScanner(strings.NewReader(str1 + "\n" + str2 + "\n"))
+
+	// Does not start with an error.
+	require.NoError(scanner.Err())
+
+	// Reads the first line.
+	require.True(scanner.Scan())
+	require.Equal([]byte(str1), scanner.Bytes())
+	require.Equal(str1, scanner.Text())
+	require.NoError(scanner.Err())
+
+	// Reads the second line.
+	require.True(scanner.Scan())
+	require.Equal([]byte(str2), scanner.Bytes())
+	require.Equal(str2, scanner.Text())
+	require.NoError(scanner.Err())
+
+	// Finishes without error.
+	require.False(scanner.Scan())
+	require.NoError(scanner.Err())
+}


### PR DESCRIPTION
We'll apply this fix to our agents, too, so they can handle programs that generate >64KB log lines. Starting with `airplane dev`.