### PR TITLE
Add Django support to init

### DIFF
--- a/pkg/ap/django/django.go
+++ b/pkg/ap/django/django.go
@@ -1,0 +1,83 @@
+package django
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/airplanedev/cli/pkg/ap"
+	"github.com/airplanedev/cli/pkg/fsx"
+	"github.com/pkg/errors"
+)
+
+// Init registers django.
+func init() {
+	ap.RegisterFramework("django", Open)
+}
+
+// Framework implementation.
+type Framework struct {
+	root string
+}
+
+// Open attempts to open at the given path.
+func Open(root string) (ap.Framework, error) {
+	var managepy = filepath.Join(root, "manage.py")
+
+	if !fsx.Exists(managepy) {
+		return nil, fmt.Errorf("django: cannot find manage.py")
+	}
+
+	return &Framework{root: root}, nil
+}
+
+// ListCommands implementation.
+func (f *Framework) ListCommands() ([]string, error) {
+	var manage = filepath.Join(f.root, "manage.py")
+
+	bin, err := f.python()
+	if err != nil {
+		return nil, err
+	}
+
+	cmd := exec.Command(bin, manage, "help", "--commands")
+	buf, err := cmd.Output()
+	if err != nil {
+		return nil, errors.Wrapf(err, "run: %s help --commands", bin)
+	}
+
+	var (
+		cmds []string
+		r    = bytes.NewReader(buf)
+		s    = bufio.NewScanner(r)
+	)
+
+	for s.Scan() {
+		if t := strings.TrimSpace(s.Text()); t != "" {
+			cmds = append(cmds, t)
+		}
+	}
+
+	sort.Strings(cmds)
+	return cmds, nil
+}
+
+// Python returns python's bin.
+//
+// We can actually run manage.py directly, but just to make this
+// more robust we'll look for python bin and execute the script using it.
+func (f *Framework) python() (string, error) {
+	var bins = [...]string{"python3", "python"}
+
+	for _, bin := range bins {
+		if p, err := exec.LookPath(bin); err == nil {
+			return p, nil
+		}
+	}
+
+	return "", fmt.Errorf("cannot find one of %v in your $PATH", bins)
+}

--- a/pkg/ap/django/django.go
+++ b/pkg/ap/django/django.go
@@ -62,6 +62,10 @@ func (f *Framework) ListCommands() ([]string, error) {
 		}
 	}
 
+	if err := s.Err(); err != nil {
+		return nil, errors.Wrapf(err, "scanning manage.py output")
+	}
+
 	sort.Strings(cmds)
 	return cmds, nil
 }

--- a/pkg/ap/django/django_test.go
+++ b/pkg/ap/django/django_test.go
@@ -9,8 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const managepy = `
-#!/usr/bin/env python3
+const managepy = `#!/usr/bin/env python3
 
 print("task_2")
 print("task_1")
@@ -47,11 +46,12 @@ func TestFramework(t *testing.T) {
 	t.Run("list commands", func(t *testing.T) {
 		var assert = require.New(t)
 		var root = tmpdir(t)
+		var bin = filepath.Join(root, "manage.py")
 
-		err := ioutil.WriteFile(
-			filepath.Join(root, "manage.py"),
+		err := os.WriteFile(
+			bin,
 			[]byte(managepy),
-			0777,
+			0770,
 		)
 		assert.NoError(err)
 

--- a/pkg/ap/django/django_test.go
+++ b/pkg/ap/django/django_test.go
@@ -9,11 +9,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const managepy = `#!/usr/bin/env python3
-
+const (
+	managepy = `#!/usr/bin/env python3
 print("task_2")
-print("task_1")
-`
+print("task_1")`
+	boom = `#!/usr/bin/env python3
+	\\
+	`
+)
 
 func TestFramework(t *testing.T) {
 	t.Run("missing manage.py", func(t *testing.T) {
@@ -61,6 +64,26 @@ func TestFramework(t *testing.T) {
 		cmds, err := f.ListCommands()
 		assert.NoError(err)
 		assert.Equal([]string{"task_1", "task_2"}, cmds)
+	})
+
+	t.Run("list command error", func(t *testing.T) {
+		var assert = require.New(t)
+		var root = tmpdir(t)
+		var bin = filepath.Join(root, "manage.py")
+
+		err := os.WriteFile(
+			bin,
+			[]byte(boom),
+			0770,
+		)
+		assert.NoError(err)
+
+		f, err := Open(root)
+		assert.NoError(err)
+
+		_, err = f.ListCommands()
+		assert.Error(err)
+		assert.Contains(err.Error(), "unexpected character")
 	})
 }
 

--- a/pkg/ap/django/django_test.go
+++ b/pkg/ap/django/django_test.go
@@ -1,0 +1,82 @@
+package django
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const managepy = `
+#!/usr/bin/env python3
+
+print("task_2")
+print("task_1")
+`
+
+func TestFramework(t *testing.T) {
+	t.Run("missing manage.py", func(t *testing.T) {
+		var assert = require.New(t)
+		var root = tmpdir(t)
+
+		f, err := Open(root)
+
+		assert.Error(err)
+		assert.Nil(f)
+	})
+
+	t.Run("has manage.py", func(t *testing.T) {
+		var assert = require.New(t)
+		var root = tmpdir(t)
+
+		err := ioutil.WriteFile(
+			filepath.Join(root, "manage.py"),
+			[]byte(managepy),
+			0777,
+		)
+		assert.NoError(err)
+
+		f, err := Open(root)
+
+		assert.NoError(err)
+		assert.NotNil(f)
+	})
+
+	t.Run("list commands", func(t *testing.T) {
+		var assert = require.New(t)
+		var root = tmpdir(t)
+
+		err := ioutil.WriteFile(
+			filepath.Join(root, "manage.py"),
+			[]byte(managepy),
+			0777,
+		)
+		assert.NoError(err)
+
+		f, err := Open(root)
+		assert.NoError(err)
+
+		cmds, err := f.ListCommands()
+		assert.NoError(err)
+		assert.Equal([]string{"task_1", "task_2"}, cmds)
+	})
+}
+
+// Tmpdir creates a temporary directory for the duration
+// of the given t.
+func tmpdir(t testing.TB) string {
+	t.Helper()
+
+	path, err := ioutil.TempDir("", "airplane_")
+	if err != nil {
+		t.Fatalf("tmpdir: %s", err)
+	}
+
+	t.Cleanup(func() {
+		os.RemoveAll(path)
+	})
+
+	return path
+}

--- a/pkg/ap/frameworks.go
+++ b/pkg/ap/frameworks.go
@@ -1,0 +1,57 @@
+package ap
+
+import (
+	"fmt"
+	"sort"
+)
+
+var (
+	// Frameworks is a mapping of framework names to framework adapters.
+	frameworks = make(map[string]FrameworkAdapter)
+)
+
+// FrameworkAdapter accepts a root path and returns
+// a new initialized framework.
+//
+// Typically, the method checks to see if the root path
+// has the necessary files for the framework, if one of the
+// files is missing the adapter returns an error.
+type FrameworkAdapter func(root string) (Framework, error)
+
+// RegisterFramework registers a framework with name and adapter.
+//
+// If the framework is already registered the function panics.
+func RegisterFramework(name string, adapter FrameworkAdapter) {
+	if _, ok := frameworks[name]; ok {
+		panic(fmt.Sprintf("ap: %q framework is already registered", name))
+	}
+	frameworks[name] = adapter
+}
+
+// LookupFramework returns a new initialized framework with
+// name and root path.
+//
+// If the framework does not exist, an error is returned.
+func LookupFramework(name, root string) (Framework, error) {
+	if adapter, ok := frameworks[name]; ok {
+		return adapter(root)
+	}
+	return nil, fmt.Errorf("ap: framework %q does not exist", name)
+}
+
+// ListFrameworks returns a slice of sorted framework names.
+func ListFrameworks() (names []string) {
+	for name := range frameworks {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return
+}
+
+// Framework represents a framework.
+type Framework interface {
+	// ListCommands lists all commands.
+	//
+	// When there are no commands, a nil slice and error are returned.
+	ListCommands() ([]string, error)
+}

--- a/pkg/ap/project_test.go
+++ b/pkg/ap/project_test.go
@@ -1,0 +1,53 @@
+package ap
+
+import (
+	"errors"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestProjects(t *testing.T) {
+	t.Run("read missing", func(t *testing.T) {
+		var assert = require.New(t)
+		var root = tmpdir(t)
+
+		_, err := ReadProject(root)
+
+		assert.Error(err)
+		assert.True(errors.Is(err, ErrNoProject))
+	})
+
+	t.Run("save, read", func(t *testing.T) {
+		var assert = require.New(t)
+		var root = tmpdir(t)
+		var project = NewProject(root)
+
+		project.Framework = "django"
+		err := project.Save()
+		assert.NoError(err)
+
+		p, err := ReadProject(root)
+		assert.NoError(err)
+		assert.Equal(p, project)
+	})
+}
+
+// Tmpdir creates a temporary directory for the duration
+// of the given t.
+func tmpdir(t testing.TB) string {
+	t.Helper()
+
+	path, err := ioutil.TempDir("", "airplane_")
+	if err != nil {
+		t.Fatalf("tmpdir: %s", err)
+	}
+
+	t.Cleanup(func() {
+		os.RemoveAll(path)
+	})
+
+	return path
+}

--- a/pkg/ap/projects.go
+++ b/pkg/ap/projects.go
@@ -1,0 +1,72 @@
+package ap
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"path/filepath"
+
+	"github.com/airplanedev/cli/pkg/fsx"
+	"github.com/pkg/errors"
+)
+
+const (
+	projectfile = "airplane.json"
+)
+
+var (
+	// ErrNoProject represents a missing project file.
+	ErrNoProject = errors.New("ap: missing " + projectfile)
+)
+
+// Project represents an Airplane project.
+//
+// On the filesystem it is persisted as `airplane.json`
+// at the root of the project.
+type Project struct {
+	root      string
+	Framework string   `json:"framework"`
+	Tasks     []string `json:"tasks"`
+}
+
+// NewProject returns a new empty project at root.
+func NewProject(root string) *Project {
+	return &Project{root: root}
+}
+
+// ReadProject reads a project from the given root.
+func ReadProject(root string) (*Project, error) {
+	var path = filepath.Join(root, projectfile)
+	var proj = Project{root: root}
+
+	if !fsx.Exists(path) {
+		return nil, ErrNoProject
+	}
+
+	buf, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, errors.Wrapf(err, "reading %s", projectfile)
+	}
+
+	if err := json.Unmarshal(buf, &proj); err != nil {
+		return nil, errors.Wrapf(err, "unmarshal %s", projectfile)
+	}
+
+	return &proj, nil
+}
+
+// Save saves the project.
+func (p *Project) Save() error {
+	var path = filepath.Join(p.root, projectfile)
+
+	buf, err := json.MarshalIndent(p, "", "  ")
+	if err != nil {
+		return errors.Wrap(err, "marshal project")
+	}
+
+	err = ioutil.WriteFile(path, buf, 0600)
+	if err != nil {
+		return errors.Wrapf(err, "write %s", projectfile)
+	}
+
+	return nil
+}

--- a/pkg/cmd/tasks/initcmd/project.go
+++ b/pkg/cmd/tasks/initcmd/project.go
@@ -1,0 +1,88 @@
+package initcmd
+
+import (
+	"context"
+	"path/filepath"
+
+	"github.com/AlecAivazis/survey/v2"
+	"github.com/airplanedev/cli/pkg/ap"
+	_ "github.com/airplanedev/cli/pkg/ap/django"
+	"github.com/airplanedev/cli/pkg/logger"
+	"github.com/pkg/errors"
+)
+
+// Project initializes a project.
+func project(ctx context.Context, name string) error {
+	root, err := filepath.Abs(".")
+	if err != nil {
+		return errors.Wrap(err, "filepath.abs(.)")
+	}
+
+	project, err := ap.ReadProject(root)
+
+	if errors.Is(err, ap.ErrNoProject) {
+		return createProject(name, root)
+	}
+
+	if err != nil {
+		return err
+	}
+
+	logger.Log("Project file already exists with %d tasks.", len(project.Tasks))
+	logger.Log("You can deploy all tasks using:")
+	logger.Log("  airplane deploy airplane.json")
+	return nil
+}
+
+// CreateProject creates a new project with framework name at root.
+func createProject(name, root string) error {
+	f, err := ap.LookupFramework(name, root)
+	if err != nil {
+		return err
+	}
+
+	cmds, err := f.ListCommands()
+	if err != nil {
+		return err
+	}
+
+	if len(cmds) == 0 {
+		return errors.Errorf("could not find any commands")
+	}
+
+	cmds, err = selectCommands(cmds)
+	if err != nil {
+		return err
+	}
+
+	if len(cmds) == 0 {
+		return errors.Errorf("you must select at least one command")
+	}
+
+	project := ap.NewProject(root)
+	project.Framework = name
+	project.Tasks = cmds
+	if err := project.Save(); err != nil {
+		return err
+	}
+
+	logger.Log("Saved project file with %d tasks", len(cmds))
+	logger.Log("You can deploy all tasks using:")
+	logger.Log("  airplane deploy airplane.json")
+	return nil
+}
+
+// SelectCommands prompts the user to select commands.
+func selectCommands(cmds []string) ([]string, error) {
+	var selected []string
+	var multi = survey.MultiSelect{
+		Message: "Which commands would you like to add to Airplane?",
+		Options: cmds,
+	}
+
+	if err := survey.AskOne(&multi, &selected); err != nil {
+		return nil, err
+	}
+
+	return selected, nil
+}


### PR DESCRIPTION
The PR adds Django support to the init command, I would like to merge
this as soon as possible, even if deploy is not implemented yet it doesn't block
us from releasing the CLI because `--use` is hidden and not documented.

See the individual commit descriptions for more info, but the gist is to
add support for:

```bash
$ airplane init --use django
```

I don't like the `--use` flag and i would like to find a better name
so suggestions are welcome! :)

Unlike `init --slug <slug> <path>` the command is expected to be run from
a root of the project. It prompts the user to select which commands they
would like to include in the airplane.json file.

Once this is merged, all deploy will have to do is the following:

- [ ] Read the `airplane.json` file and list the commands
- [ ] For each command, figure out its `api.Parameters`
- [ ] Create/Update tasks accordingly (this will likely need bulk API endpoint)
- [ ] Build a single dockerfile.
- [ ] For every task adjust the entrypoint.