### PR TITLE
Update python template format to reflect common styling

### DIFF
--- a/pkg/runtime/python/python.go
+++ b/pkg/runtime/python/python.go
@@ -21,7 +21,7 @@ func init() {
 var code = template.Must(template.New("py").Parse(`{{.Comment}}
 
 def main(params):
-  print('parameters: ', params);
+    print("parameters:", params)
 `))
 
 // Data represents the data template.


### PR DESCRIPTION
- Four spaces, not two
- Don't need extra space in "parameters:" since print() inserts spaces
- Double quotes not two
