### PR TITLE
Install node shim dependencies only if missing

### DIFF
--- a/pkg/build/node.go
+++ b/pkg/build/node.go
@@ -48,7 +48,7 @@ func node(root string, options api.KindOptions) (string, error) {
 		Workdir:        workdir,
 		HasPackageJSON: fsx.AssertExistsAll(filepath.Join(root, "package.json")) == nil,
 		HasPackageLock: fsx.AssertExistsAll(filepath.Join(root, "package-lock.json")) == nil,
-		HasShimDeps:    !HasNodeShimDeps(root),
+		HasShimDeps:    HasNodeShimDeps(root),
 		IsYarn:         fsx.AssertExistsAll(filepath.Join(root, "yarn.lock")) == nil,
 		TscArgs:        strings.Join(NodeTscArgs("/airplane", options), " \\\n"),
 	}

--- a/pkg/build/node.go
+++ b/pkg/build/node.go
@@ -48,7 +48,7 @@ func node(root string, options api.KindOptions) (string, error) {
 		Workdir:        workdir,
 		HasPackageJSON: fsx.AssertExistsAll(filepath.Join(root, "package.json")) == nil,
 		HasPackageLock: fsx.AssertExistsAll(filepath.Join(root, "package-lock.json")) == nil,
-		NeedsShimDeps:  !hasNodeDeps(root, "@types/node"),
+		NeedsShimDeps:  !HasNodeDeps(root, "@types/node"),
 		IsYarn:         fsx.AssertExistsAll(filepath.Join(root, "yarn.lock")) == nil,
 		TscArgs:        strings.Join(NodeTscArgs("/airplane", options), " \\\n"),
 	}
@@ -170,9 +170,9 @@ func NodeTscArgs(root string, opts api.KindOptions) []string {
 	}
 }
 
-// hasNodeDeps returns true if all deps are installed in the root's
+// HasNodeDeps returns true if all deps are installed in the root's
 // package.json, either as dependencies or dev dependencies.
-func hasNodeDeps(root string, deps ...string) bool {
+func HasNodeDeps(root string, deps ...string) bool {
 	pkgjsonpath := filepath.Join(root, "package.json")
 	if fsx.AssertExistsAll(pkgjsonpath) != nil {
 		return false

--- a/pkg/runtime/javascript/javascript.go
+++ b/pkg/runtime/javascript/javascript.go
@@ -149,7 +149,7 @@ func (r Runtime) PrepareRun(ctx context.Context, opts runtime.PrepareRunOptions)
 		return nil, errors.New("a package.json is missing")
 	}
 
-	if !build.HasNodeDeps(root, "@types/node") {
+	if !build.HasNodeShimDeps(root) {
 		isYarn := fsx.AssertExistsAll(filepath.Join(root, "yarn.lock")) == nil
 		var cmd *exec.Cmd
 		if isYarn {

--- a/pkg/runtime/javascript/javascript.go
+++ b/pkg/runtime/javascript/javascript.go
@@ -18,6 +18,7 @@ import (
 	"github.com/airplanedev/cli/pkg/fsx"
 	"github.com/airplanedev/cli/pkg/logger"
 	"github.com/airplanedev/cli/pkg/runtime"
+	"github.com/airplanedev/cli/pkg/utils"
 	"github.com/blang/semver/v4"
 	"github.com/pkg/errors"
 )
@@ -154,17 +155,8 @@ func (r Runtime) PrepareRun(ctx context.Context, opts runtime.PrepareRunOptions)
 	}
 
 	if !build.HasNodeShimDeps(root) {
-		isYarn := fsx.AssertExistsAll(filepath.Join(root, "yarn.lock")) == nil
-		var cmd *exec.Cmd
-		if isYarn {
-			cmd = exec.CommandContext(ctx, "yarn", "add", "-D", "@types/node")
-		} else {
-			cmd = exec.CommandContext(ctx, "npm", "install", "--save-dev", "@types/node")
-		}
-		cmd.Dir = filepath.Dir(opts.Path)
-		logger.Debug("Running %s", logger.Bold(strings.Join(cmd.Args, " ")))
-		if err := cmd.Run(); err != nil {
-			return nil, errors.New("failed to add shim dependencies")
+		if err := installShimDeps(ctx, root, opts.Path); err != nil {
+			return nil, err
 		}
 	}
 
@@ -186,6 +178,36 @@ func (r Runtime) PrepareRun(ctx context.Context, opts runtime.PrepareRunOptions)
 	}
 
 	return []string{"node", filepath.Join(root, ".airplane/dist/.airplane/shim.js"), string(pv)}, nil
+}
+
+func installShimDeps(ctx context.Context, root, path string) error {
+	isYarn := fsx.AssertExistsAll(filepath.Join(root, "yarn.lock")) == nil
+	var cmd *exec.Cmd
+	if isYarn {
+		cmd = exec.CommandContext(ctx, "yarn", "add", "-D", "@types/node")
+	} else {
+		cmd = exec.CommandContext(ctx, "npm", "install", "--save-dev", "@types/node")
+	}
+	cmd.Dir = filepath.Dir(path)
+
+	// Confirm with the user before installing the shim dependencies.
+	if utils.CanPrompt() {
+		logger.Log("Airplane needs to run %s before it can build your task.", logger.Bold(strings.Join(cmd.Args, " ")))
+		confirmed, err := utils.Confirm("Run now?")
+		if err != nil {
+			return err
+		}
+		if !confirmed {
+			return errors.New("unable to run without shim dependencies")
+		}
+	}
+
+	logger.Debug("Running %s", logger.Bold(strings.Join(cmd.Args, " ")))
+	if err := cmd.Run(); err != nil {
+		return errors.New("failed to add shim dependencies")
+	}
+
+	return nil
 }
 
 // checkTscInstalled will error if the tsc CLI is not installed.

--- a/pkg/runtime/javascript/javascript.go
+++ b/pkg/runtime/javascript/javascript.go
@@ -149,20 +149,6 @@ func (r Runtime) PrepareRun(ctx context.Context, opts runtime.PrepareRunOptions)
 		}
 	}
 
-	// hasTypesNode := fsx.AssertExistsAll(filepath.Join(root, "node_modules/@types/node"))
-	// isYarn := fsx.AssertExistsAll(filepath.Join(root, "yarn.lock")) == nil
-	// var cmd *exec.Cmd
-	// if isYarn {
-	// 	cmd = exec.CommandContext(ctx, "yarn", "add", "-D", "@types/node")
-	// } else {
-	// 	cmd = exec.CommandContext(ctx, "npm", "install", "--save-dev", "@types/node")
-	// }
-	// cmd.Dir = filepath.Dir(opts.Path)
-	// logger.Debug("Running %s", logger.Bold(strings.Join(cmd.Args, " ")))
-	// if err := cmd.Run(); err != nil {
-	// 	return nil, errors.New("failed to add @types/node dependency")
-	// }
-
 	start := time.Now()
 	cmd := exec.CommandContext(ctx, "tsc", build.NodeTscArgs(".", opts.KindOptions)...)
 	cmd.Dir = root

--- a/pkg/runtime/javascript/javascript.go
+++ b/pkg/runtime/javascript/javascript.go
@@ -142,10 +142,13 @@ func (r Runtime) PrepareRun(ctx context.Context, opts runtime.PrepareRunOptions)
 		return nil, errors.Wrap(err, "cleaning dist folder")
 	}
 
+	// Confirm we have a `package.json`, otherwise we might install shim dependencies
+	// in the wrong folder.
 	hasPkgJSON := fsx.AssertExistsAll(filepath.Join(root, "package.json")) == nil
 	if !hasPkgJSON {
 		return nil, errors.New("a package.json is missing")
 	}
+
 	if !build.HasNodeDeps(root, "@types/node") {
 		isYarn := fsx.AssertExistsAll(filepath.Join(root, "yarn.lock")) == nil
 		var cmd *exec.Cmd

--- a/pkg/runtime/javascript/javascript.go
+++ b/pkg/runtime/javascript/javascript.go
@@ -142,27 +142,29 @@ func (r Runtime) PrepareRun(ctx context.Context, opts runtime.PrepareRunOptions)
 		return nil, errors.Wrap(err, "cleaning dist folder")
 	}
 
-	if fsx.AssertExistsAll(filepath.Join(root, "package.json")) != nil {
+	hasPkgJSON := fsx.AssertExistsAll(filepath.Join(root, "package.json")) == nil
+	if !hasPkgJSON {
 		if err := os.WriteFile(filepath.Join(root, "package.json"), []byte("{}"), 0777); err != nil {
 			return nil, errors.Wrap(err, "creating default package.json")
 		}
 	}
 
-	isYarn := fsx.AssertExistsAll(filepath.Join(root, "yarn.lock")) == nil
-	var cmd *exec.Cmd
-	if isYarn {
-		cmd = exec.CommandContext(ctx, "yarn", "add", "-D", "@types/node")
-	} else {
-		cmd = exec.CommandContext(ctx, "npm", "install", "--save-dev", "@types/node")
-	}
-	cmd.Dir = filepath.Dir(opts.Path)
-	logger.Debug("Running %s", logger.Bold(strings.Join(cmd.Args, " ")))
-	if err := cmd.Run(); err != nil {
-		return nil, errors.New("failed to add @types/node dependency")
-	}
+	// hasTypesNode := fsx.AssertExistsAll(filepath.Join(root, "node_modules/@types/node"))
+	// isYarn := fsx.AssertExistsAll(filepath.Join(root, "yarn.lock")) == nil
+	// var cmd *exec.Cmd
+	// if isYarn {
+	// 	cmd = exec.CommandContext(ctx, "yarn", "add", "-D", "@types/node")
+	// } else {
+	// 	cmd = exec.CommandContext(ctx, "npm", "install", "--save-dev", "@types/node")
+	// }
+	// cmd.Dir = filepath.Dir(opts.Path)
+	// logger.Debug("Running %s", logger.Bold(strings.Join(cmd.Args, " ")))
+	// if err := cmd.Run(); err != nil {
+	// 	return nil, errors.New("failed to add @types/node dependency")
+	// }
 
 	start := time.Now()
-	cmd = exec.CommandContext(ctx, "tsc", build.NodeTscArgs(".", opts.KindOptions)...)
+	cmd := exec.CommandContext(ctx, "tsc", build.NodeTscArgs(".", opts.KindOptions)...)
 	cmd.Dir = root
 	logger.Debug("Running %s (in %s)", logger.Bold(strings.Join(cmd.Args, " ")), root)
 	out, err := cmd.CombinedOutput()

--- a/pkg/utils/prompt.go
+++ b/pkg/utils/prompt.go
@@ -9,10 +9,11 @@ import (
 )
 
 func Confirm(question string) (bool, error) {
-	ok := false
+	ok := true
 	if err := survey.AskOne(
 		&survey.Confirm{
 			Message: question,
+			Default: ok,
 		},
 		&ok,
 		survey.WithStdio(os.Stdin, os.Stderr, os.Stderr),


### PR DESCRIPTION
This PR improves the behavior for installing shim dependencies (currently just `@types/node`) in `airplane dev` and in our Node builder. Both will now check if `@types/node` is installed in the task's `package.json` and skip over the extra `npm install` if it isn't needed. For `airplane dev`, that means we only have to run `npm install` at most once per task rather than once per `airplane dev` invocation. This is a significant speed-up for projects with large dep trees. For our Node builder, this saves a bit of time since we only run one `npm install` rather than two (`npm install` vs. `npm install && npm install --save-dev @types/node`).