### PR TITLE
Fix workdir missing omitempty directive

### DIFF
--- a/pkg/taskdir/definitions/def_0_2.go
+++ b/pkg/taskdir/definitions/def_0_2.go
@@ -55,7 +55,7 @@ type GoDefinition struct {
 }
 
 type NodeDefinition struct {
-	Workdir     string `yaml:"workdir" mapstructure:"workdir"`
+	Workdir     string `yaml:"workdir,omitempty" mapstructure:"workdir"`
 	Entrypoint  string `yaml:"entrypoint" mapstructure:"entrypoint"`
 	Language    string `yaml:"language" mapstructure:"language"`
 	NodeVersion string `yaml:"nodeVersion" mapstructure:"nodeVersion"`


### PR DESCRIPTION
This was breaking existing YAML files because they didn't contain
`workdir`:

```
Error: Error reading myTask/myTask.yml

Node: workdir is required
```
