### PR TITLE
Improve layer caching

### DIFF
--- a/pkg/build/node.go
+++ b/pkg/build/node.go
@@ -95,10 +95,10 @@ func node(root string, options api.KindOptions) (string, error) {
 
 		RUN npm install -g typescript@4.2
 
-		COPY . /airplane
-
 		{{if not .HasPackageJSON}}
 		RUN echo '{}' > /airplane/package.json
+		{{else}}
+		ADD package.json ./airplane
 		{{end}}
 
 		{{if .IsYarn}}
@@ -114,6 +114,8 @@ func node(root string, options api.KindOptions) (string, error) {
 		RUN npm install @types/node
 		{{end}}
 		{{end}}
+
+		ADD . /airplane
 
 		RUN mkdir -p /airplane/.airplane/dist && \
 			echo '{{.Shim}}' > /airplane/.airplane/shim.ts && \

--- a/pkg/build/node.go
+++ b/pkg/build/node.go
@@ -94,11 +94,10 @@ func node(root string, options api.KindOptions) (string, error) {
 		RUN [ -z "${BUILD_NPM_TOKEN}" ] || echo "//registry.npmjs.org/:_authToken=${BUILD_NPM_TOKEN}" > .npmrc
 
 		RUN npm install -g typescript@4.2
+		COPY . /airplane
 
 		{{if not .HasPackageJSON}}
 		RUN echo '{}' > /airplane/package.json
-		{{else}}
-		ADD package.json ./airplane
 		{{end}}
 
 		{{if .IsYarn}}
@@ -114,8 +113,6 @@ func node(root string, options api.KindOptions) (string, error) {
 		RUN npm install @types/node
 		{{end}}
 		{{end}}
-
-		ADD . /airplane
 
 		RUN mkdir -p /airplane/.airplane/dist && \
 			echo '{{.Shim}}' > /airplane/.airplane/shim.ts && \

--- a/pkg/build/python.go
+++ b/pkg/build/python.go
@@ -38,13 +38,13 @@ func python(root string, args api.KindOptions) (string, error) {
     WORKDIR /airplane
     RUN mkdir -p .airplane && echo '{{.Shim}}' > .airplane/shim.py
 		{{if .HasRequirements}}
-		ADD requirements.txt .
+		COPY requirements.txt .
     RUN pip install -r requirements.txt
 		{{end}}
     {{if not .HasInit}}
     RUN touch __init__.py
     {{end}}
-    ADD . .
+    COPY . .
     ENTRYPOINT ["python", ".airplane/shim.py"]
 	`
 

--- a/pkg/build/python.go
+++ b/pkg/build/python.go
@@ -37,13 +37,14 @@ func python(root string, args api.KindOptions) (string, error) {
     FROM {{ .Base }}
     WORKDIR /airplane
     RUN mkdir -p .airplane && echo '{{.Shim}}' > .airplane/shim.py
+		{{if .HasRequirements}}
+		ADD requirements.txt .
+    RUN pip install -r requirements.txt
+		{{end}}
     {{if not .HasInit}}
     RUN touch __init__.py
     {{end}}
-    COPY . .
-		{{if .HasRequirements}}
-    RUN pip install -r requirements.txt
-		{{end}}
+    ADD . .
     ENTRYPOINT ["python", ".airplane/shim.py"]
 	`
 

--- a/pkg/build/python.go
+++ b/pkg/build/python.go
@@ -49,7 +49,6 @@ func python(root string, args api.KindOptions) (string, error) {
 		Base            string
 		Shim            string
 		HasRequirements bool
-		HasInit         bool
 	}{
 		Base:            v.String(),
 		Shim:            strings.Join(strings.Split(shim, "\n"), "\\n\\\n"),

--- a/pkg/build/python.go
+++ b/pkg/build/python.go
@@ -37,10 +37,10 @@ func python(root string, args api.KindOptions) (string, error) {
     FROM {{ .Base }}
     WORKDIR /airplane
     RUN mkdir -p .airplane && echo '{{.Shim}}' > .airplane/shim.py
-		{{if .HasRequirements}}
-		COPY requirements.txt .
+    {{if .HasRequirements}}
+    COPY requirements.txt .
     RUN pip install -r requirements.txt
-		{{end}}
+    {{end}}
     {{if not .HasInit}}
     RUN touch __init__.py
     {{end}}

--- a/pkg/build/python.go
+++ b/pkg/build/python.go
@@ -41,9 +41,6 @@ func python(root string, args api.KindOptions) (string, error) {
     COPY requirements.txt .
     RUN pip install -r requirements.txt
     {{end}}
-    {{if not .HasInit}}
-    RUN touch __init__.py
-    {{end}}
     COPY . .
     ENTRYPOINT ["python", ".airplane/shim.py"]
 	`
@@ -57,7 +54,6 @@ func python(root string, args api.KindOptions) (string, error) {
 		Base:            v.String(),
 		Shim:            strings.Join(strings.Split(shim, "\n"), "\\n\\\n"),
 		HasRequirements: fsx.Exists(filepath.Join(root, "requirements.txt")),
-		HasInit:         fsx.Exists(filepath.Join(root, "__init__.py")),
 	})
 	if err != nil {
 		return "", errors.Wrapf(err, "rendering dockerfile")

--- a/pkg/build/versions.json
+++ b/pkg/build/versions.json
@@ -38,8 +38,8 @@
   "python": {
     "3": {
       "image": "registry.hub.docker.com/library/python",
-      "tag": "3.9.4-buster",
-      "digest": "sha256:b004a71e38f8ace26e7554d5c2fa802a8bb39a5818cbe10ab49fd0b408a40c20"
+      "tag": "3.9.4-alpine3.13",
+      "digest": "sha256:419a7502c95b49946fbdd8228b32243597d9e9f191ddfe5468a3b9b3fe64051d"
     }
   }
 }


### PR DESCRIPTION
When a docker layer changes docker will invalidate all subsequent layers. This means that if we do the following:

	ADD . /src
	RUN npm install /src/package.json

It means that every time a user changes their source code we will re-install the package.json, instead we should do the following:

	ADD package.json /src
	RUN npm install /src/package.json
	ADD . /src

