### PR TITLE
Use `airplane dev` instead of `airplane exec`

### DIFF
--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -38,11 +38,9 @@ func New() *cobra.Command {
 		Use:   "airplane <command>",
 		Short: "Airplane CLI",
 		Example: heredoc.Doc(`
-			airplane deploy -f ./task.yml
-			airplane execute my_task
-
-			airplane deploy -f github.com/airplanedev/examples/node/hello-world-javascript/airplane.yml
-			airplane execute hello_world
+			airplane init --slug <slug> ./path/to/script
+			airplane dev ./path/to/script
+			airplane deploy ./path/to/script
 		`),
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			if c, err := conf.ReadDefault(); err == nil {

--- a/pkg/cmd/tasks/deploy/script.go
+++ b/pkg/cmd/tasks/deploy/script.go
@@ -116,7 +116,7 @@ func deployFromScript(ctx context.Context, cfg config) error {
 		return err
 	}
 
-	cmd := fmt.Sprintf("airplane execute %s", cfg.file)
+	cmd := fmt.Sprintf("airplane dev %s", cfg.file)
 	if len(def.Parameters) > 0 {
 		cmd += " -- [parameters]"
 	}

--- a/pkg/cmd/tasks/deploy/script.go
+++ b/pkg/cmd/tasks/deploy/script.go
@@ -116,13 +116,13 @@ func deployFromScript(ctx context.Context, cfg config) error {
 		return err
 	}
 
-	cmd := fmt.Sprintf("airplane dev %s", cfg.file)
+	cmd := fmt.Sprintf("airplane exec %s", cfg.file)
 	if len(def.Parameters) > 0 {
 		cmd += " -- [parameters]"
 	}
 
 	logger.Suggest(
-		"⚡ To execute the task locally:",
+		"⚡ To execute the task from the CLI:",
 		cmd,
 	)
 

--- a/pkg/cmd/tasks/deploy/yaml.go
+++ b/pkg/cmd/tasks/deploy/yaml.go
@@ -132,7 +132,7 @@ func deployFromYaml(ctx context.Context, cfg config) error {
 		return errors.Wrapf(err, "updating task %s", def.Slug)
 	}
 
-	cmd := fmt.Sprintf("airplane execute %s", def.Slug)
+	cmd := fmt.Sprintf("airplane dev %s", def.Slug)
 	if len(def.Parameters) > 0 {
 		cmd += " -- [parameters]"
 	}

--- a/pkg/cmd/tasks/deploy/yaml.go
+++ b/pkg/cmd/tasks/deploy/yaml.go
@@ -132,7 +132,7 @@ func deployFromYaml(ctx context.Context, cfg config) error {
 		return errors.Wrapf(err, "updating task %s", def.Slug)
 	}
 
-	cmd := fmt.Sprintf("airplane dev %s", def.Slug)
+	cmd := fmt.Sprintf("airplane exec %s", def.Slug)
 	if len(def.Parameters) > 0 {
 		cmd += " -- [parameters]"
 	}

--- a/pkg/cmd/tasks/deploy/yaml.go
+++ b/pkg/cmd/tasks/deploy/yaml.go
@@ -136,10 +136,16 @@ func deployFromYaml(ctx context.Context, cfg config) error {
 	if len(def.Parameters) > 0 {
 		cmd += " -- [parameters]"
 	}
-	logger.Log(`
-To execute %s:
-- From the CLI: %s
-- From the UI: %s`, def.Name, cmd, client.TaskURL(def.Slug))
+
+	logger.Suggest(
+		"⚡ To execute the task from the CLI:",
+		cmd,
+	)
+
+	logger.Suggest(
+		"⚡ To execute the task from the UI:",
+		client.TaskURL(def.Slug),
+	)
 
 	return nil
 }

--- a/pkg/cmd/tasks/initcmd/init.go
+++ b/pkg/cmd/tasks/initcmd/init.go
@@ -67,8 +67,6 @@ func run(ctx context.Context, cfg config) error {
 		return fmt.Errorf("expected <path> %q to have a file extension", cfg.file)
 	}
 
-	logger.Step("Initializing %s", cfg.file)
-
 	r, ok := runtime.Lookup(cfg.file)
 	if !ok {
 		return fmt.Errorf("unable to deploy task with %q file extension", ext)
@@ -91,7 +89,7 @@ func run(ctx context.Context, cfg config) error {
 
 		if slug, ok := runtime.Slug(buf); ok && slug == task.Slug {
 			logger.Step("%s is already linked to %s", cfg.file, cfg.slug)
-			suggest(cfg.file)
+			suggestNextSteps(cfg.file)
 			return nil
 		}
 
@@ -115,7 +113,7 @@ func run(ctx context.Context, cfg config) error {
 		}
 
 		logger.Step("Linked %s to %s", cfg.file, cfg.slug)
-		suggest(cfg.file)
+		suggestNextSteps(cfg.file)
 		return nil
 	}
 
@@ -132,21 +130,20 @@ func run(ctx context.Context, cfg config) error {
 		return err
 	}
 
-	logger.Step("Wrote starter code to %s", cfg.file)
-	suggest(cfg.file)
+	logger.Step("Created %s", cfg.file)
+	suggestNextSteps(cfg.file)
 	return nil
 }
 
-// suggest suggests next steps.
-func suggest(file string) {
-	logger.Suggest(
-		"🛫 To deploy your task to Airplane:",
-		"airplane deploy %s",
-		file,
-	)
+func suggestNextSteps(file string) {
 	logger.Suggest(
 		"⚡ To execute the task locally:",
 		"airplane dev %s",
+		file,
+	)
+	logger.Suggest(
+		"🛫 To deploy your task to Airplane:",
+		"airplane deploy %s",
 		file,
 	)
 }

--- a/pkg/cmd/tasks/initcmd/init.go
+++ b/pkg/cmd/tasks/initcmd/init.go
@@ -132,7 +132,7 @@ func run(ctx context.Context, cfg config) error {
 		return err
 	}
 
-	logger.Step("Write starter code to %s", cfg.file)
+	logger.Step("Wrote starter code to %s", cfg.file)
 	suggest(cfg.file)
 	return nil
 }

--- a/pkg/cmd/tasks/initcmd/init.go
+++ b/pkg/cmd/tasks/initcmd/init.go
@@ -146,7 +146,7 @@ func suggest(file string) {
 	)
 	logger.Suggest(
 		"⚡ To execute the task locally:",
-		"airplane execute %s",
+		"airplane dev %s",
 		file,
 	)
 }


### PR DESCRIPTION
Replaces references to locally executing with `airplane dev` commands.