### PR TITLE
Add support for zero-param JS scripts

### DIFF
--- a/pkg/build/node-shim.ts
+++ b/pkg/build/node-shim.ts
@@ -14,7 +14,21 @@ async function main() {
   }
 
   try {
-    await task(JSON.parse(process.argv[2]));
+    // The task function will either be:
+    //  - () => void
+    //  - () => Promise<void>
+    //  - (params: object) => void
+    //  - (params: object) => Promise<void>
+    //
+    // At build-time, TS will know what the type of the task function is.
+    // Therefore, cast as `any` so that TS doesn't throw an error if
+    // task does not expect a parameter.
+    //
+    // We could add a type assertion here to enforce that users don't supply
+    // a function that doesn't match one of the signatures above, however
+    // the TS error that users would see would not be easy to read, even with
+    // TS familiarity.
+    await (task as any)(JSON.parse(process.argv[2]));
   } catch (err) {
     console.error(err);
     console.log(


### PR DESCRIPTION
Previously, a task that exported a function without a parameter would generate a build-time TS error. We now handle that case:

```ts
// This previously failed.
export default async function() {
  console.log('hello world')
}

// This previously worked, and continues to work today.
export default async function (params: any) {
  console.log('hello world', params)
}
```