### PR TITLE
Turn off debug logging on retryablehttp.NewClient

### DIFF
--- a/pkg/api/client.go
+++ b/pkg/api/client.go
@@ -29,6 +29,8 @@ func init() {
 	rc.RetryMax = 5
 	rc.RetryWaitMin = 50 * time.Millisecond
 	rc.RetryWaitMax = 1 * time.Second
+	// Disable DEBUG log messages:
+	rc.Logger = nil
 	client = rc.StandardClient()
 }
 


### PR DESCRIPTION
This gets rid of all the `[DEBUG]` logs when making HTTP requests.

```
[build] Pushing image...
2021/06/28 22:45:03 [DEBUG] GET https://api.airplane.so:5000/v0/builds/get?id=bui20210628zw2ku7h
2021/06/28 22:45:04 [DEBUG] GET https://api.airplane.so:5000/v0/builds/getLogs?buildID=bui20210628zw2ku7h&since=2021-06-28T22%3A45%3A01-04%3A00
[build] Pushing image...
[build] Pushed image
2021/06/28 22:45:04 [DEBUG] GET https://api.airplane.so:5000/v0/builds/get?id=bui20210628zw2ku7h
2021/06/28 22:45:05 [DEBUG] GET https://api.airplane.so:5000/v0/builds/getLogs?buildID=bui20210628zw2ku7h&since=2021-06-28T22%3A45%3A04-04%3A00
2021/06/28 22:45:05 [DEBUG] GET https://api.airplane.so:5000/v0/builds/get?id=bui20210628zw2ku7h
```