### PR TITLE
Fix issue with inlining of Python shim

### DIFF
--- a/pkg/build/node-shim.ts
+++ b/pkg/build/node-shim.ts
@@ -1,5 +1,5 @@
 // This file includes a shim that will execute your task code.
-import task from "../{{.Entrypoint}}";
+import task from "{{.Entrypoint}}";
 
 async function main() {
   if (process.argv.length !== 3) {

--- a/pkg/build/node.go
+++ b/pkg/build/node.go
@@ -127,6 +127,8 @@ func NodeShim(entrypoint string) (string, error) {
 	// Remove the `.ts` suffix if one exists, since tsc doesn't accept
 	// import paths with `.ts` endings. `.js` endings are fine.
 	entrypoint = strings.TrimSuffix(entrypoint, ".ts")
+	// The shim is stored under the .airplane directory.
+	entrypoint = filepath.Join("../", entrypoint)
 
 	shim, err := applyTemplate(nodeShim, struct {
 		Entrypoint string

--- a/pkg/build/versions.go
+++ b/pkg/build/versions.go
@@ -8,6 +8,18 @@ import (
 )
 
 //go:embed versions.json
+//
+// If you change the versions in this file, make sure to:
+//   1. Update the digest to match. The tags are just a convenience to note
+//      which version the digest correlates to without consulting DockerHub.
+//   2. Manually push the new base images into the public cache in the
+//      Airplane Registry. See Slab:
+//      https://airplane.slab.com/posts/publishing-to-the-public-cache-registry-8bzwq93d
+//   3. Alpine-based images will not work with shim-based builders, but it's
+//      a straightforward change if we end up wanting it (different echo
+//      semantics than debian-based images). These base images are cached on
+//      our agents, so for the most part, we don't need to worry about the
+//      size of the base image.
 var versionsJSON []byte
 
 // Versions contains a mapping table of (builder, version) to

--- a/pkg/build/versions.json
+++ b/pkg/build/versions.json
@@ -38,8 +38,8 @@
   "python": {
     "3": {
       "image": "registry.hub.docker.com/library/python",
-      "tag": "3.9.4-alpine3.13",
-      "digest": "sha256:419a7502c95b49946fbdd8228b32243597d9e9f191ddfe5468a3b9b3fe64051d"
+      "tag": "3.9.4-buster",
+      "digest": "sha256:b004a71e38f8ace26e7554d5c2fa802a8bb39a5818cbe10ab49fd0b408a40c20"
     }
   }
 }


### PR DESCRIPTION
[When we moved the Python base image to alpine](https://github.com/airplanedev/cli/pull/195/files), that changed the semantics of `echo`, which broke how we inlined the Python shim into the `Dockerfile`.

@yields -- I'm moving back to debian for Python for now, but let's chat more about this when you're back!


## Before

```
❯ lairlocal deploy ./python_task.py --local --debug && docker run --rm -it --entrypoint cat us-central1-docker.pkg.dev/airplane-prod/team-1jq9ndetctmyqqxajesk7v0wxav/task-tsk20210629zare8kl:latest .airplane/shim.py

...

# This file includes a shim that will execute your task code.\n\nimport importlib.util as util\nimport json\nimport sys\nimport os\n\ndef run(args):\n	if len(args) != 2:\n		raise Exception("usage: python ./shim.py <args>")\n\n	spec = util.spec_from_file_location("mod.main", "/python_task.py")\n	mod = util.module_from_spec(spec)\n	spec.loader.exec_module(mod)\n\n	try:\n		mod.main(json.loads(args[1]))\n	except Exception as e:\n		raise Exception("executing /python_task.py") from e\n\nif __name__ == "__main__":\n	run(sys.argv)\n
```


## After

```
❯ lairlocal deploy ./python_task.py --local --debug && docker run --rm -it --entrypoint cat us-central1-docker.pkg.dev/airplane-prod/team-1jq9ndetctmyqqxajesk7v0wxav/task-tsk20210629zare8kl:latest .airplane/shim.py

...

# This file includes a shim that will execute your task code.

import importlib.util as util
import json
import sys
import os

def run(args):
	if len(args) != 2:
		raise Exception("usage: python ./shim.py <args>")

	spec = util.spec_from_file_location("mod.main", "/python_task.py")
	mod = util.module_from_spec(spec)
	spec.loader.exec_module(mod)

	try:
		mod.main(json.loads(args[1]))
	except Exception as e:
		raise Exception("executing /python_task.py") from e

if __name__ == "__main__":
	run(sys.argv)
```