### PR TITLE
Fix Python entrypoint and import path

### DIFF
--- a/pkg/build/python-shim.py
+++ b/pkg/build/python-shim.py
@@ -5,7 +5,7 @@ import json
 import sys
 
 def run(args):
-    sys.path.append("{{.Taskroot}}")
+    sys.path.append("{{.TaskRoot}}")
     
     if len(args) != 2:
         raise Exception("usage: python ./shim.py <args>")

--- a/pkg/build/python-shim.py
+++ b/pkg/build/python-shim.py
@@ -3,20 +3,21 @@
 import importlib.util as util
 import json
 import sys
-import os
 
 def run(args):
-	if len(args) != 2:
-		raise Exception("usage: python ./shim.py <args>")
+    sys.path.append("{{.Taskroot}}")
+    
+    if len(args) != 2:
+        raise Exception("usage: python ./shim.py <args>")
 
-	spec = util.spec_from_file_location("mod.main", "{{ .Entrypoint }}")
-	mod = util.module_from_spec(spec)
-	spec.loader.exec_module(mod)
+    spec = util.spec_from_file_location("mod.main", "{{ .Entrypoint }}")
+    mod = util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
 
-	try:
-		mod.main(json.loads(args[1]))
-	except Exception as e:
-		raise Exception("executing {{.Entrypoint}}") from e
+    try:
+        mod.main(json.loads(args[1]))
+    except Exception as e:
+        raise Exception("executing {{.Entrypoint}}") from e
 
 if __name__ == "__main__":
-	run(sys.argv)
+    run(sys.argv)

--- a/pkg/build/python.go
+++ b/pkg/build/python.go
@@ -65,12 +65,12 @@ func python(root string, args api.KindOptions) (string, error) {
 var pythonShim string
 
 // PythonShim generates a shim file for running Python tasks.
-func PythonShim(taskroot, entrypoint string) (string, error) {
+func PythonShim(taskRoot, entrypoint string) (string, error) {
 	shim, err := applyTemplate(pythonShim, struct {
-		Taskroot   string
+		TaskRoot   string
 		Entrypoint string
 	}{
-		Taskroot:   taskroot,
+		TaskRoot:   taskRoot,
 		Entrypoint: entrypoint,
 	})
 	if err != nil {

--- a/pkg/build/python.go
+++ b/pkg/build/python.go
@@ -28,7 +28,7 @@ func python(root string, args api.KindOptions) (string, error) {
 		return "", err
 	}
 
-	shim, err := PythonShim(entrypoint)
+	shim, err := PythonShim("/airplane", entrypoint)
 	if err != nil {
 		return "", err
 	}
@@ -65,10 +65,12 @@ func python(root string, args api.KindOptions) (string, error) {
 var pythonShim string
 
 // PythonShim generates a shim file for running Python tasks.
-func PythonShim(entrypoint string) (string, error) {
+func PythonShim(taskroot, entrypoint string) (string, error) {
 	shim, err := applyTemplate(pythonShim, struct {
+		Taskroot   string
 		Entrypoint string
 	}{
+		Taskroot:   taskroot,
 		Entrypoint: entrypoint,
 	})
 	if err != nil {

--- a/pkg/cmd/tasks/deploy/script.go
+++ b/pkg/cmd/tasks/deploy/script.go
@@ -61,14 +61,15 @@ func deployFromScript(ctx context.Context, cfg config) error {
 	// Detect the root of the task, if found ensure
 	// that the entrypoint and the root are included
 	// in the build.
-	var taskroot = filepath.Dir(abs)
-
-	if root, err := r.Root(abs); err == nil {
-		setEntrypoint(&def, strings.TrimPrefix(abs, root))
-		taskroot = root
-	} else {
-		setEntrypoint(&def, filepath.Base(abs))
+	taskroot, err := r.Root(abs)
+	if err != nil {
+		return err
 	}
+	entrypoint, err := filepath.Rel(taskroot, abs)
+	if err != nil {
+		return err
+	}
+	setEntrypoint(&def, entrypoint)
 
 	// TODO(amir): move to `d.SetWorkdir()`.
 	if def.Node != nil {

--- a/pkg/runtime/python/python.go
+++ b/pkg/runtime/python/python.go
@@ -59,7 +59,7 @@ func (r Runtime) PrepareRun(ctx context.Context, opts runtime.PrepareRunOptions)
 	if err != nil {
 		return nil, errors.Wrap(err, "entrypoint is not within the task root")
 	}
-	shim, err := build.PythonShim(entrypoint)
+	shim, err := build.PythonShim(root, entrypoint)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Fixes entrypoint from e.g. /task/my_command.py to task/my_command.py -
it shouldn't be an absolute path, this was breaking the shim import.

Fixes shim to append the taskroot to `sys.path` - otherwise,
task/my_command.py would not be able to import mod:

```
. is task root
task/
  my_command.py
mod/
  __init__.py
```

Also, switches python-shim.py to four-space indents instead of tabs.
