### PR TITLE
Add dom to tsclib to fix crash on e.g. `window`

### DIFF
--- a/pkg/build/node.go
+++ b/pkg/build/node.go
@@ -145,10 +145,10 @@ func NodeShim(entrypoint string) (string, error) {
 func NodeTscArgs(root string, opts api.KindOptions) []string {
 	// https://github.com/tsconfig/bases/blob/master/bases/node16.json
 	tscTarget := "es2020"
-	tscLib := "es2020"
+	tscLib := "es2020,dom"
 	if strings.HasPrefix(opts["nodeVersion"].(string), "12") {
 		tscTarget = "es2019"
-		tscLib = "es2019"
+		tscLib = "es2019,dom"
 	}
 
 	return []string{

--- a/pkg/cmd/tasks/deploy/script.go
+++ b/pkg/cmd/tasks/deploy/script.go
@@ -105,6 +105,7 @@ func deployFromScript(ctx context.Context, cfg config) (rErr error) {
 		return err
 	}
 
+	props.buildLocal = cfg.local
 	resp, err := build.Run(ctx, build.Request{
 		Local:   cfg.local,
 		Client:  client,
@@ -114,11 +115,10 @@ func deployFromScript(ctx context.Context, cfg config) (rErr error) {
 		TaskEnv: def.Env,
 		Shim:    true,
 	})
-	props.buildLocal = cfg.local
-	props.buildID = resp.BuildID
 	if err != nil {
 		return err
 	}
+	props.buildID = resp.BuildID
 
 	_, err = client.UpdateTask(ctx, api.UpdateTaskRequest{
 		Slug:             def.Slug,


### PR DESCRIPTION
This allows `typeof window === "undefined"` checks in code, which won't
otherwise compile in TS:

    error TS2304: Cannot find name 'window'

Also fixes a nil pointer crash when `resp` is nil because `build.Run`
errored.
