### PR TITLE
Fix indentation of dockerfile templates

### DIFF
--- a/pkg/build/node.go
+++ b/pkg/build/node.go
@@ -82,42 +82,42 @@ func node(root string, options api.KindOptions) (string, error) {
 	// Down the road, we may want to give customers more control over this build process
 	// in which case we could introduce an extra step for performing build commands.
 	return applyTemplate(`
-		FROM {{.Base}}
+FROM {{.Base}}
 
-		WORKDIR /airplane{{.Workdir}}
+WORKDIR /airplane{{.Workdir}}
 
-		# Support setting BUILD_NPM_RC or BUILD_NPM_TOKEN to configure private registry auth
-		ARG BUILD_NPM_RC
-		ARG BUILD_NPM_TOKEN
-		RUN [ -z "${BUILD_NPM_RC}" ] || echo "${BUILD_NPM_RC}" > .npmrc
-		RUN [ -z "${BUILD_NPM_TOKEN}" ] || echo "//registry.npmjs.org/:_authToken=${BUILD_NPM_TOKEN}" > .npmrc
+# Support setting BUILD_NPM_RC or BUILD_NPM_TOKEN to configure private registry auth
+ARG BUILD_NPM_RC
+ARG BUILD_NPM_TOKEN
+RUN [ -z "${BUILD_NPM_RC}" ] || echo "${BUILD_NPM_RC}" > .npmrc
+RUN [ -z "${BUILD_NPM_TOKEN}" ] || echo "//registry.npmjs.org/:_authToken=${BUILD_NPM_TOKEN}" > .npmrc
 
-		RUN npm install -g typescript@4.2
-		COPY . /airplane
+RUN npm install -g typescript@4.2
+COPY . /airplane
 
-		{{if not .HasPackageJSON}}
-		RUN echo '{}' > /airplane/package.json
-		{{end}}
+{{if not .HasPackageJSON}}
+RUN echo '{}' > /airplane/package.json
+{{end}}
 
-		{{if .IsYarn}}
-		{{if .HasShimDeps}}
-		RUN yarn --non-interactive
-		{{else}}
-		RUN yarn add --non-interactive @types/node
-		{{end}}
-		{{else}}
-		{{if .HasShimDeps}}
-		RUN npm install
-		{{else}}
-		RUN npm install @types/node
-		{{end}}
-		{{end}}
+{{if .IsYarn}}
+{{if .HasShimDeps}}
+RUN yarn --non-interactive
+{{else}}
+RUN yarn add --non-interactive @types/node
+{{end}}
+{{else}}
+{{if .HasShimDeps}}
+RUN npm install
+{{else}}
+RUN npm install @types/node
+{{end}}
+{{end}}
 
-		RUN mkdir -p /airplane/.airplane/dist && \
-			{{.InlineShim}} > /airplane/.airplane/shim.ts && \
-			tsc {{.TscArgs}}
-		ENTRYPOINT ["node", "/airplane/.airplane/dist/.airplane/shim.js"]
-	`, cfg)
+RUN mkdir -p /airplane/.airplane/dist && \
+	{{.InlineShim}} > /airplane/.airplane/shim.ts && \
+	tsc {{.TscArgs}}
+ENTRYPOINT ["node", "/airplane/.airplane/dist/.airplane/shim.js"]
+`, cfg)
 }
 
 //go:embed node-shim.ts
@@ -269,24 +269,24 @@ func nodeLegacyBuilder(root string, options api.KindOptions) (string, error) {
 	}
 
 	return applyTemplate(`
-		FROM {{ .Base }}
-		
-		WORKDIR {{ .Workdir }}
-		
-		# Support setting BUILD_NPM_RC or BUILD_NPM_TOKEN to configure private registry auth
-		ARG BUILD_NPM_RC
-		ARG BUILD_NPM_TOKEN
-		RUN [ -z "${BUILD_NPM_RC}" ] || echo "${BUILD_NPM_RC}" > .npmrc
-		RUN [ -z "${BUILD_NPM_TOKEN}" ] || echo "//registry.npmjs.org/:_authToken=${BUILD_NPM_TOKEN}" > .npmrc
-		
-		COPY . {{ .Workdir }}
-		{{ range .Commands }}
-		RUN {{ . }}
-		{{ end }}
-		
-		WORKDIR {{ .BuildWorkdir }}
-		ENTRYPOINT ["node", "{{ .Main }}"]
-	`, struct {
+FROM {{ .Base }}
+
+WORKDIR {{ .Workdir }}
+
+# Support setting BUILD_NPM_RC or BUILD_NPM_TOKEN to configure private registry auth
+ARG BUILD_NPM_RC
+ARG BUILD_NPM_TOKEN
+RUN [ -z "${BUILD_NPM_RC}" ] || echo "${BUILD_NPM_RC}" > .npmrc
+RUN [ -z "${BUILD_NPM_TOKEN}" ] || echo "//registry.npmjs.org/:_authToken=${BUILD_NPM_TOKEN}" > .npmrc
+
+COPY . {{ .Workdir }}
+{{ range .Commands }}
+RUN {{ . }}
+{{ end }}
+
+WORKDIR {{ .BuildWorkdir }}
+ENTRYPOINT ["node", "{{ .Main }}"]
+`, struct {
 		Base         string
 		Workdir      string
 		BuildWorkdir string

--- a/pkg/build/node.go
+++ b/pkg/build/node.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/MakeNowJust/heredoc"
 	"github.com/airplanedev/cli/pkg/api"
 	"github.com/airplanedev/cli/pkg/fsx"
 	"github.com/airplanedev/cli/pkg/logger"
@@ -81,43 +82,43 @@ func node(root string, options api.KindOptions) (string, error) {
 	//
 	// Down the road, we may want to give customers more control over this build process
 	// in which case we could introduce an extra step for performing build commands.
-	return applyTemplate(`
-FROM {{.Base}}
+	return applyTemplate(heredoc.Doc(`
+		FROM {{.Base}}
 
-WORKDIR /airplane{{.Workdir}}
+		WORKDIR /airplane{{.Workdir}}
 
-# Support setting BUILD_NPM_RC or BUILD_NPM_TOKEN to configure private registry auth
-ARG BUILD_NPM_RC
-ARG BUILD_NPM_TOKEN
-RUN [ -z "${BUILD_NPM_RC}" ] || echo "${BUILD_NPM_RC}" > .npmrc
-RUN [ -z "${BUILD_NPM_TOKEN}" ] || echo "//registry.npmjs.org/:_authToken=${BUILD_NPM_TOKEN}" > .npmrc
+		# Support setting BUILD_NPM_RC or BUILD_NPM_TOKEN to configure private registry auth
+		ARG BUILD_NPM_RC
+		ARG BUILD_NPM_TOKEN
+		RUN [ -z "${BUILD_NPM_RC}" ] || echo "${BUILD_NPM_RC}" > .npmrc
+		RUN [ -z "${BUILD_NPM_TOKEN}" ] || echo "//registry.npmjs.org/:_authToken=${BUILD_NPM_TOKEN}" > .npmrc
 
-RUN npm install -g typescript@4.2
-COPY . /airplane
+		RUN npm install -g typescript@4.2
+		COPY . /airplane
 
-{{if not .HasPackageJSON}}
-RUN echo '{}' > /airplane/package.json
-{{end}}
+		{{if not .HasPackageJSON}}
+		RUN echo '{}' > /airplane/package.json
+		{{end}}
 
-{{if .IsYarn}}
-{{if .HasShimDeps}}
-RUN yarn --non-interactive
-{{else}}
-RUN yarn add --non-interactive @types/node
-{{end}}
-{{else}}
-{{if .HasShimDeps}}
-RUN npm install
-{{else}}
-RUN npm install @types/node
-{{end}}
-{{end}}
+		{{if .IsYarn}}
+		{{if .HasShimDeps}}
+		RUN yarn --non-interactive
+		{{else}}
+		RUN yarn add --non-interactive @types/node
+		{{end}}
+		{{else}}
+		{{if .HasShimDeps}}
+		RUN npm install
+		{{else}}
+		RUN npm install @types/node
+		{{end}}
+		{{end}}
 
-RUN mkdir -p /airplane/.airplane/dist && \
-	{{.InlineShim}} > /airplane/.airplane/shim.ts && \
-	tsc {{.TscArgs}}
-ENTRYPOINT ["node", "/airplane/.airplane/dist/.airplane/shim.js"]
-`, cfg)
+		RUN mkdir -p /airplane/.airplane/dist && \
+			{{.InlineShim}} > /airplane/.airplane/shim.ts && \
+			tsc {{.TscArgs}}
+		ENTRYPOINT ["node", "/airplane/.airplane/dist/.airplane/shim.js"]
+	`), cfg)
 }
 
 //go:embed node-shim.ts
@@ -268,25 +269,25 @@ func nodeLegacyBuilder(root string, options api.KindOptions) (string, error) {
 		return "", err
 	}
 
-	return applyTemplate(`
-FROM {{ .Base }}
+	return applyTemplate(heredoc.Doc(`
+		FROM {{ .Base }}
 
-WORKDIR {{ .Workdir }}
+		WORKDIR {{ .Workdir }}
 
-# Support setting BUILD_NPM_RC or BUILD_NPM_TOKEN to configure private registry auth
-ARG BUILD_NPM_RC
-ARG BUILD_NPM_TOKEN
-RUN [ -z "${BUILD_NPM_RC}" ] || echo "${BUILD_NPM_RC}" > .npmrc
-RUN [ -z "${BUILD_NPM_TOKEN}" ] || echo "//registry.npmjs.org/:_authToken=${BUILD_NPM_TOKEN}" > .npmrc
+		# Support setting BUILD_NPM_RC or BUILD_NPM_TOKEN to configure private registry auth
+		ARG BUILD_NPM_RC
+		ARG BUILD_NPM_TOKEN
+		RUN [ -z "${BUILD_NPM_RC}" ] || echo "${BUILD_NPM_RC}" > .npmrc
+		RUN [ -z "${BUILD_NPM_TOKEN}" ] || echo "//registry.npmjs.org/:_authToken=${BUILD_NPM_TOKEN}" > .npmrc
 
-COPY . {{ .Workdir }}
-{{ range .Commands }}
-RUN {{ . }}
-{{ end }}
+		COPY . {{ .Workdir }}
+		{{ range .Commands }}
+		RUN {{ . }}
+		{{ end }}
 
-WORKDIR {{ .BuildWorkdir }}
-ENTRYPOINT ["node", "{{ .Main }}"]
-`, struct {
+		WORKDIR {{ .BuildWorkdir }}
+		ENTRYPOINT ["node", "{{ .Main }}"]
+	`), struct {
 		Base         string
 		Workdir      string
 		BuildWorkdir string

--- a/pkg/build/python.go
+++ b/pkg/build/python.go
@@ -34,16 +34,16 @@ func python(root string, args api.KindOptions) (string, error) {
 	}
 
 	const dockerfile = `
-    FROM {{ .Base }}
-    WORKDIR /airplane
-    RUN mkdir -p .airplane && {{.InlineShim}} > .airplane/shim.py
-    {{if .HasRequirements}}
-    COPY requirements.txt .
-    RUN pip install -r requirements.txt
-    {{end}}
-    COPY . .
-    ENTRYPOINT ["python", ".airplane/shim.py"]
-	`
+FROM {{ .Base }}
+WORKDIR /airplane
+RUN mkdir -p .airplane && {{.InlineShim}} > .airplane/shim.py
+{{if .HasRequirements}}
+COPY requirements.txt .
+RUN pip install -r requirements.txt
+{{end}}
+COPY . .
+ENTRYPOINT ["python", ".airplane/shim.py"]
+`
 
 	df, err := applyTemplate(dockerfile, struct {
 		Base            string
@@ -91,15 +91,15 @@ func pythonLegacy(root string, args api.KindOptions) (string, error) {
 	}
 
 	t, err := template.New("python").Parse(`
-    FROM {{ .Base }}
-    WORKDIR /airplane
-		{{if not .HasRequirements}}
-		RUN echo > requirements.txt
-		{{end}}
-    COPY . .
-    RUN pip install -r requirements.txt
-    ENTRYPOINT ["python", "/airplane/{{ .Entrypoint }}"]
-	`)
+FROM {{ .Base }}
+WORKDIR /airplane
+{{if not .HasRequirements}}
+RUN echo > requirements.txt
+{{end}}
+COPY . .
+RUN pip install -r requirements.txt
+ENTRYPOINT ["python", "/airplane/{{ .Entrypoint }}"]
+`)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/build/python.go
+++ b/pkg/build/python.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"text/template"
 
+	"github.com/MakeNowJust/heredoc"
 	"github.com/airplanedev/cli/pkg/api"
 	"github.com/airplanedev/cli/pkg/fsx"
 	"github.com/pkg/errors"
@@ -33,17 +34,17 @@ func python(root string, args api.KindOptions) (string, error) {
 		return "", err
 	}
 
-	const dockerfile = `
-FROM {{ .Base }}
-WORKDIR /airplane
-RUN mkdir -p .airplane && {{.InlineShim}} > .airplane/shim.py
-{{if .HasRequirements}}
-COPY requirements.txt .
-RUN pip install -r requirements.txt
-{{end}}
-COPY . .
-ENTRYPOINT ["python", ".airplane/shim.py"]
-`
+	dockerfile := heredoc.Doc(`
+		FROM {{ .Base }}
+		WORKDIR /airplane
+		RUN mkdir -p .airplane && {{.InlineShim}} > .airplane/shim.py
+		{{if .HasRequirements}}
+		COPY requirements.txt .
+		RUN pip install -r requirements.txt
+		{{end}}
+		COPY . .
+		ENTRYPOINT ["python", ".airplane/shim.py"]
+	`)
 
 	df, err := applyTemplate(dockerfile, struct {
 		Base            string
@@ -90,16 +91,16 @@ func pythonLegacy(root string, args api.KindOptions) (string, error) {
 		return "", err
 	}
 
-	t, err := template.New("python").Parse(`
-FROM {{ .Base }}
-WORKDIR /airplane
-{{if not .HasRequirements}}
-RUN echo > requirements.txt
-{{end}}
-COPY . .
-RUN pip install -r requirements.txt
-ENTRYPOINT ["python", "/airplane/{{ .Entrypoint }}"]
-`)
+	t, err := template.New("python").Parse(heredoc.Doc(`
+		FROM {{ .Base }}
+		WORKDIR /airplane
+		{{if not .HasRequirements}}
+		RUN echo > requirements.txt
+		{{end}}
+		COPY . .
+		RUN pip install -r requirements.txt
+		ENTRYPOINT ["python", "/airplane/{{ .Entrypoint }}"]
+	`))
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Just to reduce confusion and improve consistency, this dedents our
dockerfile templates so there's no question of how leading space is
interpreted.

Before this, we had a mix of spaces/tabs, and Docker docs discourage
leading whitespace: https://docs.docker.com/engine/reference/builder/

> For backward compatibility, leading whitespace before comments (#) and
> instructions (such as RUN) are ignored, but discouraged.
