### PR TITLE
Add cli_version property to track events

### DIFF
--- a/pkg/analytics/analytics.go
+++ b/pkg/analytics/analytics.go
@@ -94,7 +94,9 @@ func Track(c *cli.Config, event string, properties map[string]interface{}) {
 		return
 	}
 	tok := c.ParseTokenForAnalytics()
-	props := analytics.NewProperties().Set("team_id", tok.TeamID)
+	props := analytics.NewProperties().
+		Set("team_id", tok.TeamID).
+		Set("cli_version", version.Get())
 	for k, v := range properties {
 		props = props.Set(k, v)
 	}


### PR DESCRIPTION
While we include this in the segment app context, including it on the
track itself allows us to see it in e.g. Heap.
