### PR TITLE
Improve `tsc` auto-installation message

### DIFF
--- a/pkg/build/node.go
+++ b/pkg/build/node.go
@@ -147,7 +147,7 @@ func NodeTscArgs(root string, opts api.KindOptions) []string {
 	// https://github.com/tsconfig/bases/blob/master/bases/node16.json
 	tscTarget := "es2020"
 	tscLib := "es2020,dom"
-	if strings.HasPrefix(opts["nodeVersion"].(string), "12") {
+	if opts != nil && strings.HasPrefix(opts["nodeVersion"].(string), "12") {
 		tscTarget = "es2019"
 		tscLib = "es2019,dom"
 	}

--- a/pkg/runtime/javascript/javascript.go
+++ b/pkg/runtime/javascript/javascript.go
@@ -116,7 +116,8 @@ func (r Runtime) FormatComment(s string) string {
 
 func (r Runtime) PrepareRun(ctx context.Context, opts runtime.PrepareRunOptions) ([]string, error) {
 	checkNodeVersion(ctx, opts.KindOptions)
-	if err := checkTscInstalled(ctx); err != nil {
+	tscGlobal, err := checkTscInstalled(ctx)
+	if err != nil {
 		return nil, err
 	}
 
@@ -160,7 +161,12 @@ func (r Runtime) PrepareRun(ctx context.Context, opts runtime.PrepareRunOptions)
 	}
 
 	start := time.Now()
-	cmd := exec.CommandContext(ctx, "npx", append([]string{"-p", "typescript", "--no", "tsc", "--"}, build.NodeTscArgs(".", opts.KindOptions)...)...)
+	var cmd *exec.Cmd
+	if tscGlobal {
+		cmd = exec.CommandContext(ctx, "tsc", build.NodeTscArgs(".", opts.KindOptions)...)
+	} else {
+		cmd = exec.CommandContext(ctx, "npx", append([]string{"-p", "typescript", "--no", "tsc", "--"}, build.NodeTscArgs(".", opts.KindOptions)...)...)
+	}
 	cmd.Dir = root
 	logger.Debug("Running %s (in %s)", logger.Bold(strings.Join(cmd.Args, " ")), root)
 	out, err := cmd.CombinedOutput()
@@ -209,38 +215,52 @@ func installShimDeps(ctx context.Context, root, path string) error {
 	return nil
 }
 
-// checkTscInstalled will verify that the Typescript CLI is installed
-// and confirm with the user if they are okay with us auto-installing it.
-func checkTscInstalled(ctx context.Context) error {
+// checkTscInstalled will verify that the Typescript CLI is installed.
+//
+// If not installed, it will auto-install tsc.
+//
+// Returns true if tsc is available locally and false if available globally.
+func checkTscInstalled(ctx context.Context) (bool, error) {
+	// Check if the user has tsc installed in their local node_modules:
 	// note: --no will prevent installing typescript if not already installed.
 	cmd := exec.CommandContext(ctx, "npx", "-p", "typescript", "--no", "tsc", "--", "--version")
 	logger.Debug("Running %s", logger.Bold(strings.Join(cmd.Args, " ")))
 	if out, err := cmd.CombinedOutput(); err == nil {
 		logger.Debug("TypeScript version: %s", strings.TrimPrefix(strings.TrimSpace(string(out)), "Version "))
 		// tsc is installed, return early
-		return nil
+		return true, nil
+	}
+
+	// Otherwise, try and see if they have it installed globally.
+	cmd = exec.CommandContext(ctx, "tsc", "--version")
+	logger.Debug("Running %s", logger.Bold(strings.Join(cmd.Args, " ")))
+	if out, err := cmd.CombinedOutput(); err == nil {
+		logger.Debug("TypeScript version: %s", strings.TrimPrefix(strings.TrimSpace(string(out)), "Version "))
+		// tsc is installed, return early
+		return false, nil
 	}
 
 	// Typescript is not installed. Confirm with the user if they are
 	// okay with installing it.
-	cmd = exec.CommandContext(ctx, "npx", "-p", "typescript", "--yes", "tsc", "--version")
+	cmd = exec.CommandContext(ctx, "npm", "install", "--global", "typescript")
 	if utils.CanPrompt() {
 		logger.Log("Airplane needs to run %s to install the TypeScript CLI.", logger.Bold(strings.Join(cmd.Args, " ")))
 		confirmed, err := utils.Confirm("Run now?")
 		if err != nil {
-			return err
+			return false, err
 		}
 		if !confirmed {
-			return errors.New("unable to run without the TypeScript CLI")
+			return false, errors.New("unable to run without the TypeScript CLI")
 		}
 	}
 
 	logger.Debug("Running %s", logger.Bold(strings.Join(cmd.Args, " ")))
 	if err := cmd.Run(); err != nil {
-		return errors.Wrap(err, "installing tsc")
+		return false, errors.Wrap(err, "installing tsc")
 	}
 
-	return nil
+	// Since we installed tsc globally, return false.
+	return false, nil
 }
 
 // checkNodeVersion compares the major version of the currently installed


### PR DESCRIPTION
Previously, we showed a rather confusing `npx`-based installation message. We also didn't use `tsc` if installed globally since `npx` does not use global tsc installations (it has its own global cache that is separate from `npm install --global`).

With this PR, if you have `tsc` installed in your local `node_modules`, you'll see:

```sh
❯ airplane dev tsc/echo_loop.js --debug
...
[debug] Running npx -p typescript --no tsc -- --version
[debug] TypeScript version: 4.3.5
[debug] Running npx -p typescript --no tsc -- --allowJs --module commonjs --target es2020 --lib es2020,dom --esModuleInterop --outDir .airplane/dist --rootDir . --skipLibCheck --pretty .airplane/shim.ts (in /Users/colin/dev/airplanedev/test)
...
```

Otherwise, if you have `tsc` installed in your PATH, you'll see:

```sh
❯ airplane dev tsc/echo_loop.js --debug
...
[debug] Running npx -p typescript --no tsc -- --version ## <- this failed! so it tries your path instead
[debug] Running tsc --version
[debug] TypeScript version: 4.3.3
[debug] Running tsc --allowJs --module commonjs --target es2020 --lib es2020,dom --esModuleInterop --outDir .airplane/dist --rootDir . --skipLibCheck --pretty .airplane/shim.ts (in /Users/colin/dev/airplanedev/test)
...
```

Otherwise, you don't have `tsc` installed, so you'll see:

```sh
❯ which tsc
tsc not found

❯ airplane dev tsc/echo_loop.js --debug
...
[debug] Running npx -p typescript --no tsc -- --version
[debug] Running tsc --version
Airplane needs to run npm install --global typescript to install the TypeScript CLI.
? Run now? Yes
[debug] Running npm install --global typescript
[debug] Running tsc --allowJs --module commonjs --target es2020 --lib es2020,dom --esModuleInterop --outDir .airplane/dist --rootDir . --skipLibCheck --pretty .airplane/shim.ts (in /Users/colin/dev/airplanedev/test)
...

❯ which tsc
# yup idk https://twitter.com/maydayitscolink/status/1413230869024739345?s=20
/opt/homebrew/bin/tsc
```

Resolves AIR-1356