### PR TITLE
Simplify `airplane exec` example when a task has deployed

### DIFF
--- a/pkg/cmd/tasks/deploy/script.go
+++ b/pkg/cmd/tasks/deploy/script.go
@@ -141,11 +141,8 @@ func deployFromScript(ctx context.Context, cfg config) (rErr error) {
 		return err
 	}
 
+	// Leave off `-- [parameters]` for simplicity - user will get prompted.
 	cmd := fmt.Sprintf("airplane exec %s", cfg.file)
-	if len(def.Parameters) > 0 {
-		cmd += " -- [parameters]"
-	}
-
 	logger.Suggest(
 		"⚡ To execute the task from the CLI:",
 		cmd,

--- a/pkg/cmd/tasks/deploy/yaml.go
+++ b/pkg/cmd/tasks/deploy/yaml.go
@@ -158,11 +158,8 @@ func deployFromYaml(ctx context.Context, cfg config) (rErr error) {
 		return errors.Wrapf(err, "updating task %s", def.Slug)
 	}
 
+	// Leave off `-- [parameters]` for simplicity - user will get prompted.
 	cmd := fmt.Sprintf("airplane exec %s", def.Slug)
-	if len(def.Parameters) > 0 {
-		cmd += " -- [parameters]"
-	}
-
 	logger.Suggest(
 		"⚡ To execute the task from the CLI:",
 		cmd,


### PR DESCRIPTION
It's easier for the user to just `airplane exec [slug]` instead of
trying to figure out the `--flags`.
