### PR TITLE
Update install script to from /usr/local to $HOME/.airplane

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -19,7 +19,7 @@ else
     download_uri="https://github.com/airplanedev/cli/releases/download/${1}/airplane_${target}.tar.gz"
 fi
 
-airplane_install="${AIRPLANE_INSTALL:-/usr/local}"
+airplane_install="${AIRPLANE_INSTALL:-$HOME/.airplane}"
 bin_dir="$airplane_install/bin"
 exe="$bin_dir/airplane"
 


### PR DESCRIPTION
It's not safe to assume /usr/local is writeable - folks coming from
non-homebrew setups (vanilla setups) especially have trouble.

For now, we'll write to $HOME/.airplane and (still) have the
instructinos asking user to add it to $PATH.
