### PR TITLE
Refactor analytics.ReportError and ignore terminal.InterruptErr

### DIFF
--- a/cmd/airplane/main.go
+++ b/cmd/airplane/main.go
@@ -10,7 +10,6 @@ import (
 	"github.com/airplanedev/cli/pkg/logger"
 	"github.com/airplanedev/cli/pkg/trap"
 	"github.com/airplanedev/cli/pkg/utils"
-	"github.com/getsentry/sentry-go"
 	"github.com/pkg/errors"
 	_ "github.com/segmentio/events/v2/text"
 )
@@ -42,10 +41,7 @@ func main() {
 		}
 		logger.Log("")
 
-		sentryID := sentry.CaptureException(err)
-		if sentryID != nil {
-			logger.Debug("Sentry event ID: %s", *sentryID)
-		}
+		analytics.ReportError(err)
 
 		analytics.Close()
 		os.Exit(1)

--- a/pkg/analytics/analytics.go
+++ b/pkg/analytics/analytics.go
@@ -1,8 +1,10 @@
 package analytics
 
 import (
+	"errors"
 	"time"
 
+	"github.com/AlecAivazis/survey/v2/terminal"
 	"github.com/airplanedev/cli/pkg/cli"
 	"github.com/airplanedev/cli/pkg/conf"
 	"github.com/airplanedev/cli/pkg/logger"
@@ -126,4 +128,20 @@ func enqueue(msg analytics.Message) {
 		// Log (but otherwise suppress) the error
 		sentry.CaptureException(err)
 	}
+}
+
+// ReportError sends an error to Sentry, unless filtered
+func ReportError(err error) {
+	if ignoreError(err) {
+		return
+	}
+	sentryID := sentry.CaptureException(err)
+	if sentryID != nil {
+		logger.Debug("Sentry event ID: %s", *sentryID)
+	}
+}
+
+func ignoreError(err error) bool {
+	// For now, all this does is handle survey's interrupt error.
+	return errors.Is(err, terminal.InterruptErr)
 }


### PR DESCRIPTION
terminal.InterruptErr is returned from survey when ctrl-c'd during a
prompt. Ignore those errors.
