### PR TITLE
Improve init and deploy when run from home directory

### DIFF
--- a/pkg/build/remote.go
+++ b/pkg/build/remote.go
@@ -276,7 +276,8 @@ func confirmBuildRoot(root string) error {
 	} else if home != root {
 		return nil
 	}
-	logger.Warning("This task's root is your home directory–deploying will attempt to upload the entire directory.")
+	logger.Warning("This task's root is your home directory — deploying will attempt to upload the entire directory.")
+	logger.Warning("Consider moving your task entrypoint to a subdirectory.")
 	if ok, err := utils.Confirm("Are you sure?"); err != nil {
 		return err
 	} else if !ok {

--- a/pkg/build/remote.go
+++ b/pkg/build/remote.go
@@ -16,11 +16,15 @@ import (
 	"github.com/airplanedev/cli/pkg/build/ignore"
 	"github.com/airplanedev/cli/pkg/logger"
 	"github.com/airplanedev/cli/pkg/taskdir/definitions"
+	"github.com/airplanedev/cli/pkg/utils"
 	"github.com/dustin/go-humanize"
 	"github.com/pkg/errors"
 )
 
 func remote(ctx context.Context, req Request) (*Response, error) {
+	if err := confirmBuildRoot(req.Root); err != nil {
+		return nil, err
+	}
 	buildLog(api.LogLevelInfo, logger.Gray("Building with %s as root...", relpath(req.Root)))
 
 	// Before performing a remote build, we must first update kind/kindOptions
@@ -42,6 +46,7 @@ func remote(ctx context.Context, req Request) (*Response, error) {
 	defer os.RemoveAll(tmpdir)
 
 	archivePath := path.Join(tmpdir, "archive.tar.gz")
+	buildLog(api.LogLevelInfo, logger.Gray("Packaging and uploading %s to build the task...", req.Root))
 	if err := archiveTaskDir(req.Def, req.Root, archivePath); err != nil {
 		return nil, err
 	}
@@ -263,4 +268,19 @@ func relpath(root string) string {
 		}
 	}
 	return root
+}
+
+func confirmBuildRoot(root string) error {
+	if home, err := os.UserHomeDir(); err != nil {
+		return errors.Wrap(err, "getting home dir")
+	} else if home != root {
+		return nil
+	}
+	logger.Warning("This task's root is your home directory–deploying will attempt to upload the entire directory.")
+	if ok, err := utils.Confirm("Are you sure?"); err != nil {
+		return err
+	} else if !ok {
+		return errors.New("aborting build")
+	}
+	return nil
 }

--- a/pkg/cmd/tasks/initcmd/init.go
+++ b/pkg/cmd/tasks/initcmd/init.go
@@ -24,6 +24,7 @@ import (
 	_ "github.com/airplanedev/cli/pkg/runtime/shell"
 	_ "github.com/airplanedev/cli/pkg/runtime/typescript"
 	"github.com/airplanedev/cli/pkg/utils"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -40,46 +41,57 @@ func New(c *cli.Config) *cobra.Command {
 		Use:   "init",
 		Short: "Initialize a task definition",
 		Example: heredoc.Doc(`
-			$ airplane tasks init
+			$ airplane tasks init --slug task-slug
 			$ airplane tasks init --slug task-slug ./my/task.js
 			$ airplane tasks init --slug task-slug ./my/task.ts
 		`),
-		Args: cobra.ExactArgs(1),
+		Args: cobra.MaximumNArgs(1),
 		PersistentPreRunE: utils.WithParentPersistentPreRunE(func(cmd *cobra.Command, args []string) error {
 			return login.EnsureLoggedIn(cmd.Root().Context(), c)
 		}),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cfg.file = args[0]
+			if len(args) > 0 {
+				cfg.file = args[0]
+			}
 			return run(cmd.Root().Context(), cfg)
 		},
 	}
 
 	cmd.Flags().StringVar(&cfg.slug, "slug", "", "Slug of an existing task to generate from.")
-	cmd.MarkFlagRequired("slug")
+	if err := cmd.MarkFlagRequired("slug"); err != nil {
+		logger.Debug("error: %s", err)
+	}
 
 	return cmd
 }
 
 func run(ctx context.Context, cfg config) error {
-	var ext = filepath.Ext(cfg.file)
-	var client = cfg.client
-
-	if ext == "" {
-		return fmt.Errorf("expected <path> %q to have a file extension", cfg.file)
-	}
-
-	r, ok := runtime.Lookup(cfg.file)
-	if !ok {
-		return fmt.Errorf("unable to deploy task with %q file extension", ext)
-	}
+	client := cfg.client
 
 	task, err := client.GetTask(ctx, cfg.slug)
 	if err != nil {
 		return err
 	}
 
+	if cfg.file == "" {
+		cfg.file, err = promptForNewFileName(task)
+		if err != nil {
+			return err
+		}
+	}
+
+	ext := filepath.Ext(cfg.file)
+	if ext == "" {
+		return errors.Errorf("expected <path> %q to have a file extension", cfg.file)
+	}
+
+	r, ok := runtime.Lookup(cfg.file)
+	if !ok {
+		return errors.Errorf("unable to deploy task with %q file extension", ext)
+	}
+
 	if task.Kind != r.Kind() {
-		return fmt.Errorf("cannot link %q to a %s task", cfg.file, r.Kind())
+		return errors.Errorf("cannot link %q to a %s task", cfg.file, r.Kind())
 	}
 
 	if fsx.Exists(cfg.file) {
@@ -162,4 +174,38 @@ func patch(slug, file string) (ok bool, err error) {
 		&ok,
 	)
 	return
+}
+
+func promptForNewFileName(task api.Task) (string, error) {
+	fileName := task.Slug + runtime.SuggestExt(task.Kind)
+
+	if cwdIsHome, err := cwdIsHome(); err != nil {
+		return "", err
+	} else if cwdIsHome {
+		// Suggest a subdirectory to avoid putting a file directly into home directory.
+		fileName = filepath.Join("airplane", fileName)
+	}
+
+	if err := survey.AskOne(
+		&survey.Input{
+			Message: "Where should the script be created?",
+			Default: fileName,
+		},
+		&fileName,
+	); err != nil {
+		return "", err
+	}
+	return fileName, nil
+}
+
+func cwdIsHome() (bool, error) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return false, err
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return false, err
+	}
+	return cwd == home, nil
 }

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -110,3 +110,13 @@ func Lookup(path string) (Interface, bool) {
 	r, ok := runtimes[ext]
 	return r, ok
 }
+
+// SuggestExt returns the default extension for a given TaskKind, if any.
+func SuggestExt(kind api.TaskKind) string {
+	for ext, runtime := range runtimes {
+		if runtime.Kind() == kind {
+			return ext
+		}
+	}
+	return ""
+}


### PR DESCRIPTION
Two changes, both intended to avoid issue where user is deploying a script from
their home directory:
- Prompt for task file name if omitted from init command. This also means we
  can show a shorter command (`airplane deploy --init $SLUG`) in instructions.
  We default to `airplane/$slug` if they are in their home directory to avoid
  having a script directly in home.
- Add confirmation if uploading home directory - discourage users from doing
  this even if they manage to put a script into the home directory.
