### PR TITLE
Check CLI version in `version` and `deploy` commands

### DIFF
--- a/pkg/cmd/tasks/deploy/deploy.go
+++ b/pkg/cmd/tasks/deploy/deploy.go
@@ -10,6 +10,7 @@ import (
 	"github.com/airplanedev/cli/pkg/cmd/auth/login"
 	"github.com/airplanedev/cli/pkg/logger"
 	"github.com/airplanedev/cli/pkg/utils"
+	"github.com/airplanedev/cli/pkg/version"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -72,6 +73,10 @@ type taskDeployedProps struct {
 }
 
 func run(ctx context.Context, cfg config) error {
+	if err := version.CheckLatest(ctx); err != nil {
+		return err
+	}
+
 	ext := filepath.Ext(cfg.file)
 
 	if ext == ".yml" || ext == ".yaml" {

--- a/pkg/cmd/version/version.go
+++ b/pkg/cmd/version/version.go
@@ -30,5 +30,9 @@ func Version() string {
 func run(ctx context.Context) error {
 	logger.Log(Version())
 
+	if err := version.CheckLatest(ctx); err != nil {
+		return err
+	}
+
 	return nil
 }

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,5 +1,13 @@
 package version
 
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+
+	"github.com/airplanedev/cli/pkg/logger"
+)
+
 // Set by Go Releaser.
 var (
 	version string = "<unknown>"
@@ -12,4 +20,53 @@ func Get() string {
 
 func Date() string {
 	return date
+}
+
+const releaseURL = "https://api.github.com/repos/airplanedev/cli/releases?per_page=1"
+
+type release struct {
+	Name string `json:"name"`
+}
+
+// CheckLatest queries the GitHub API for newer releases and prints a warning if the CLI is outdated.
+func CheckLatest(ctx context.Context) error {
+	latest, err := getLatest(ctx)
+	if err != nil {
+		return err
+	}
+	if latest == "" || version == "<unknown>" {
+		// No version found or CLI version unknown - pass silently.
+		return nil
+	}
+	// Assumes not matching latest means you are behind:
+	if latest != "v"+version {
+		logger.Warning("A newer version of the Airplane CLI is available: %s", latest)
+		logger.Suggest(
+			"Visit the docs for upgrade instructions:",
+			"https://docs.airplane.dev/platform/install-the-airplane-cli#upgrading-the-cli",
+		)
+	}
+	return nil
+}
+
+func getLatest(ctx context.Context) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, "GET", releaseURL, nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Add("Accept", "application/vnd.github.v3+json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+
+	var releases []release
+	if err := json.NewDecoder(resp.Body).Decode(&releases); err != nil {
+		return "", err
+	}
+	if len(releases) == 0 {
+		return "", nil
+	}
+	return releases[0].Name, nil
 }


### PR DESCRIPTION
When running either `version` or `deploy`, this will check for a newer
version via the GitHub API and print out a warning if a newer version
exists.
