### PR TITLE
Fix error message when linking to the wrong task kind

### DIFF
--- a/pkg/cmd/tasks/initcmd/init.go
+++ b/pkg/cmd/tasks/initcmd/init.go
@@ -79,7 +79,7 @@ func run(ctx context.Context, cfg config) error {
 	}
 
 	if task.Kind != r.Kind() {
-		return fmt.Errorf("cannot link %q to a %s task", cfg.file, r.Kind())
+		return fmt.Errorf("cannot link %q to a %s task", cfg.file, task.Kind)
 	}
 
 	if fsx.Exists(cfg.file) {


### PR DESCRIPTION
Right now, this prints the runtime kind, so if you have a dockerfile
task being linked to myscript.js, you get:

    Error: Cannot link "myscript.js" to a node task

This is confusing, since you don't see what task is expected. With this
change, you get:

    Error: Cannot link "wtf.js" to a dockerfile task
