### PR TITLE
Move built Dockerfile to .airplane/Dockerfile

### DIFF
--- a/pkg/build/builder.go
+++ b/pkg/build/builder.go
@@ -148,18 +148,22 @@ func (b *Builder) Build(ctx context.Context, taskID, version string) (*Response,
 	}
 	logger.Debug(strings.TrimSpace(dockerfile))
 
-	dockerfilePath := "Dockerfile.airplane"
+	dockerfilePath := ".airplane/Dockerfile"
+	logger.Debug("writing dockerfile to %s", dockerfilePath)
+	if err := tree.MkdirAll(filepath.Dir(dockerfilePath)); err != nil {
+		return nil, err
+	}
 	if err := tree.Write(dockerfilePath, strings.NewReader(dockerfile)); err != nil {
-		return nil, errors.Wrap(err, "writing dockerfile")
+		return nil, err
 	}
 
 	if err := tree.Copy(b.root); err != nil {
-		return nil, errors.Wrapf(err, "copy %q", b.root)
+		return nil, err
 	}
 
 	bc, err := tree.Archive()
 	if err != nil {
-		return nil, errors.Wrap(err, "archive tree")
+		return nil, err
 	}
 	defer bc.Close()
 

--- a/pkg/build/tree.go
+++ b/pkg/build/tree.go
@@ -51,11 +51,19 @@ func (t *Tree) Copy(src string) error {
 	return nil
 }
 
+// MkdirAll creates dir relative to root
+func (t *Tree) MkdirAll(dir string) error {
+	if err := os.MkdirAll(filepath.Join(t.root, dir), 0777); err != nil {
+		return errors.Wrap(err, "making directory")
+	}
+	return nil
+}
+
 // Write writes the given r into dst.
 func (t *Tree) Write(dst string, r io.Reader) error {
 	buf, err := ioutil.ReadAll(r)
 	if err != nil {
-		return errors.Wrap(err, "read")
+		return errors.Wrap(err, "write")
 	}
 
 	return ioutil.WriteFile(filepath.Join(t.root, dst), buf, 0600)


### PR DESCRIPTION
In shell builder, we produce a Dockerfile (optionally based off a
user-generated Dockerfile). Rather than storing it in
Dockerfile.airplane, move it to .airplane/ where it's less likely to
conflict with anything else.
