### PR TITLE
Fix interpolating paths into python-shim with backslashes

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -60,3 +60,14 @@ func inlineString(s string) string {
 	s = strings.ReplaceAll(s, "'", `'"'"'`)
 	return "echo '" + s + "'"
 }
+
+// backslashEscape escapes s by replacing `\` with `\\` and all runes in chars with `\{rune}`.
+// Typically should backslashEscape(s, `"`) to escape backslashes and double quotes.
+func backslashEscape(s string, chars string) string {
+	// Always escape backslash
+	s = strings.ReplaceAll(s, `\`, `\\`)
+	for _, char := range chars {
+		s = strings.ReplaceAll(s, string(char), `\`+string(char))
+	}
+	return s
+}

--- a/pkg/build/node.go
+++ b/pkg/build/node.go
@@ -130,6 +130,8 @@ func NodeShim(entrypoint string) (string, error) {
 	entrypoint = strings.TrimSuffix(entrypoint, ".ts")
 	// The shim is stored under the .airplane directory.
 	entrypoint = filepath.Join("../", entrypoint)
+	// Escape for embedding into a string
+	entrypoint = backslashEscape(entrypoint, `"`)
 
 	shim, err := applyTemplate(nodeShim, struct {
 		Entrypoint string

--- a/pkg/build/python-shim.py
+++ b/pkg/build/python-shim.py
@@ -5,19 +5,19 @@ import json
 import sys
 
 def run(args):
-    sys.path.append("{{.TaskRoot}}")
+    sys.path.append(r"{{.TaskRoot}}")
     
     if len(args) != 2:
         raise Exception("usage: python ./shim.py <args>")
 
-    spec = util.spec_from_file_location("mod.main", "{{ .Entrypoint }}")
+    spec = util.spec_from_file_location("mod.main", r"{{ .Entrypoint }}")
     mod = util.module_from_spec(spec)
     spec.loader.exec_module(mod)
 
     try:
         mod.main(json.loads(args[1]))
     except Exception as e:
-        raise Exception("executing {{.Entrypoint}}") from e
+        raise Exception(r"executing {{.Entrypoint}}") from e
 
 if __name__ == "__main__":
     run(sys.argv)

--- a/pkg/build/python-shim.py
+++ b/pkg/build/python-shim.py
@@ -5,19 +5,19 @@ import json
 import sys
 
 def run(args):
-    sys.path.append(r"{{.TaskRoot}}")
+    sys.path.append("{{.TaskRoot}}")
     
     if len(args) != 2:
         raise Exception("usage: python ./shim.py <args>")
 
-    spec = util.spec_from_file_location("mod.main", r"{{ .Entrypoint }}")
+    spec = util.spec_from_file_location("mod.main", "{{ .Entrypoint }}")
     mod = util.module_from_spec(spec)
     spec.loader.exec_module(mod)
 
     try:
         mod.main(json.loads(args[1]))
     except Exception as e:
-        raise Exception(r"executing {{.Entrypoint}}") from e
+        raise Exception("executing {{.Entrypoint}}") from e
 
 if __name__ == "__main__":
     run(sys.argv)

--- a/pkg/build/python.go
+++ b/pkg/build/python.go
@@ -78,8 +78,8 @@ func PythonShim(taskRoot, entrypoint string) (string, error) {
 		TaskRoot   string
 		Entrypoint string
 	}{
-		TaskRoot:   taskRoot,
-		Entrypoint: entrypoint,
+		TaskRoot:   backslashEscape(taskRoot, `"`),
+		Entrypoint: backslashEscape(entrypoint, `"`),
 	})
 	if err != nil {
 		return "", errors.Wrapf(err, "rendering shim")

--- a/pkg/build/shell.go
+++ b/pkg/build/shell.go
@@ -82,7 +82,7 @@ func shell(root string, options api.KindOptions) (string, error) {
 		Entrypoint string
 	}{
 		InlineShim: inlineString(shim),
-		Entrypoint: entrypoint,
+		Entrypoint: backslashEscape(entrypoint, `"`),
 	})
 }
 


### PR DESCRIPTION
On windows, TaskRoot and Entrypoint have a backslashes, resulting in
`sys.path.append("foo\bar")`, which results in unexpected behavior. (One
user had `C:\Users\...` which resulted in an invalid unicode escsape
sequence.)

To fix this, this uses raw strings so that backslashes are treated as
literals.
