### PR TITLE
Detect expired CLI tokens

### DIFF
--- a/pkg/api/client.go
+++ b/pkg/api/client.go
@@ -29,8 +29,7 @@ func init() {
 	rc.RetryMax = 5
 	rc.RetryWaitMin = 50 * time.Millisecond
 	rc.RetryWaitMax = 1 * time.Second
-	// Disable DEBUG log messages:
-	rc.Logger = nil
+	rc.Logger = logger.HTTPLogger{} // Logs messages as debug output
 	client = rc.StandardClient()
 }
 

--- a/pkg/logger/http.go
+++ b/pkg/logger/http.go
@@ -1,0 +1,58 @@
+package logger
+
+import (
+	"strings"
+
+	"github.com/hashicorp/go-retryablehttp"
+)
+
+// HTTPLogger is a wrapper around the default logger that
+// can be used for HTTP requests via `hashicorp/go-retryablehttp`.
+type HTTPLogger struct{}
+
+var _ retryablehttp.LeveledLogger = HTTPLogger{}
+
+func (_ HTTPLogger) Error(msg string, keyAndValues ...interface{}) {
+	format, args := toFormatAndArgs(msg, keyAndValues)
+	Debug(format, args...)
+}
+
+func (_ HTTPLogger) Info(msg string, keyAndValues ...interface{}) {
+	format, args := toFormatAndArgs(msg, keyAndValues)
+	Debug(format, args...)
+}
+
+func (_ HTTPLogger) Debug(msg string, keyAndValues ...interface{}) {
+	format, args := toFormatAndArgs(msg, keyAndValues)
+	Debug(format, args...)
+}
+
+func (_ HTTPLogger) Warn(msg string, keyAndValues ...interface{}) {
+	format, args := toFormatAndArgs(msg, keyAndValues)
+	Debug(format, args...)
+}
+
+func toFormatAndArgs(msg string, keyAndValues []interface{}) (string, []interface{}) {
+	var keys []string
+	var args []interface{}
+	for i, v := range keyAndValues {
+		// keyAndValues is a list of format: [key, value, key, value, ...]
+		//
+		// Every time we see a value, add (key, value) to args.
+		if i%2 == 0 {
+			continue
+		}
+
+		if _, ok := keyAndValues[i-1].(string); ok {
+			keys = append(keys, "%v")
+			args = append(args, v)
+		}
+	}
+
+	format := msg
+	if len(keys) > 0 {
+		format += " " + strings.Join(keys, " ")
+	}
+
+	return format, args
+}

--- a/pkg/logger/http.go
+++ b/pkg/logger/http.go
@@ -6,7 +6,7 @@ import (
 	"github.com/hashicorp/go-retryablehttp"
 )
 
-// HTTPLogger is a wrapper around the default logger that
+// HTTPLogger is a wrapper around the default debug logger that
 // can be used for HTTP requests via `hashicorp/go-retryablehttp`.
 type HTTPLogger struct{}
 


### PR DESCRIPTION
This PR detects if a user's token is expired and sends them through the login flow again. This will happen every 3 months. We should eventually support auto-refreshing tokens.

This PR also adds a logger to `retryablehttp` that prints out HTTP logs when `--debug` is enabled.

This PR also tweaks `airplane login` to re-login even if currently logged in so that you don't need to `airplane logout` first.