### PR TITLE
Support `runs list` across all tasks

### DIFF
--- a/pkg/api/client.go
+++ b/pkg/api/client.go
@@ -10,6 +10,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
 
@@ -154,12 +155,18 @@ func (c Client) GetUniqueSlug(ctx context.Context, name, preferredSlug string) (
 }
 
 // ListRuns lists most recent runs.
-func (c Client) ListRuns(ctx context.Context, taskID string) (resp ListRunsResponse, err error) {
+func (c Client) ListRuns(ctx context.Context, req ListRunsRequest) (resp ListRunsResponse, err error) {
 	q := url.Values{
-		"taskID": []string{taskID},
-		"page":   []string{"0"},
-		"limit":  []string{"100"},
+		"page": []string{strconv.FormatInt(int64(req.Page), 10)},
 	}
+	if req.TaskID != "" {
+		q["taskID"] = []string{req.TaskID}
+	}
+	limit := 100
+	if req.Limit != 0 {
+		limit = req.Limit
+	}
+	q["limit"] = []string{strconv.FormatInt(int64(limit), 10)}
 
 	err = c.do(ctx, "GET", "/runs/list?"+q.Encode(), nil, &resp)
 	return

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -374,6 +374,7 @@ const (
 type Run struct {
 	RunID       string     `json:"runID"`
 	TaskID      string     `json:"taskID"`
+	TaskName    string     `json:"taskName"`
 	TeamID      string     `json:"teamID"`
 	Status      RunStatus  `json:"status"`
 	ParamValues Values     `json:"paramValues"`

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -373,8 +373,10 @@ const (
 // Run represents a run.
 type Run struct {
 	RunID       string     `json:"runID"`
+	TaskID      string     `json:"taskID"`
 	TeamID      string     `json:"teamID"`
 	Status      RunStatus  `json:"status"`
+	ParamValues Values     `json:"paramValues"`
 	CreatedAt   time.Time  `json:"createdAt"`
 	CreatorID   string     `json:"creatorID"`
 	QueuedAt    *time.Time `json:"queuedAt"`
@@ -383,6 +385,13 @@ type Run struct {
 	FailedAt    *time.Time `json:"failedAt"`
 	CancelledAt *time.Time `json:"cancelledAt"`
 	CancelledBy *string    `json:"cancelledBy"`
+}
+
+// ListRunsRequest represents a list runs request.
+type ListRunsRequest struct {
+	TaskID string `json:"taskID"`
+	Page   int    `json:"page"`
+	Limit  int    `json:"limit"`
 }
 
 // ListRunsResponse represents a list runs response.

--- a/pkg/cmd/runs/list/list.go
+++ b/pkg/cmd/runs/list/list.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/MakeNowJust/heredoc"
+	"github.com/airplanedev/cli/pkg/api"
 	"github.com/airplanedev/cli/pkg/cli"
 	"github.com/airplanedev/cli/pkg/print"
 	"github.com/pkg/errors"
@@ -16,18 +17,18 @@ func New(c *cli.Config) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "list",
-		Short: "Lists runs for a task",
+		Short: "Lists runs",
 		Example: heredoc.Doc(`
+			airplane runs list
 			airplane runs list --task <slug>
-			airplane runs list --task my-task -o json
+			airplane runs list --task <slug> -o json
 		`),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return run(cmd.Root().Context(), c, slug)
 		},
 	}
 
-	cmd.Flags().StringVarP(&slug, "task", "t", "", "The task slug")
-	cmd.MarkFlagRequired("task")
+	cmd.Flags().StringVarP(&slug, "task", "t", "", "Filter runs by task slug")
 
 	return cmd
 }
@@ -36,12 +37,18 @@ func New(c *cli.Config) *cobra.Command {
 func run(ctx context.Context, c *cli.Config, slug string) error {
 	var client = c.Client
 
-	task, err := client.GetTask(ctx, slug)
-	if err != nil {
-		return err
+	req := api.ListRunsRequest{}
+
+	// If a task slug was provided, look up its task ID:
+	if slug != "" {
+		task, err := client.GetTask(ctx, slug)
+		if err != nil {
+			return err
+		}
+		req.TaskID = task.ID
 	}
 
-	resp, err := client.ListRuns(ctx, task.ID)
+	resp, err := client.ListRuns(ctx, req)
 	if err != nil {
 		return errors.Wrap(err, "list runs")
 	}

--- a/pkg/print/table.go
+++ b/pkg/print/table.go
@@ -132,7 +132,7 @@ func (t Table) task(task api.Task) {
 func (t Table) runs(runs []api.Run) {
 	tw := tablewriter.NewWriter(os.Stdout)
 	tw.SetBorder(false)
-	tw.SetHeader([]string{"id", "status", "created at", "ended at"})
+	tw.SetHeader([]string{"id", "task", "status", "created at", "ended at"})
 
 	for _, run := range runs {
 		var endedAt string
@@ -148,6 +148,7 @@ func (t Table) runs(runs []api.Run) {
 
 		tw.Append([]string{
 			run.RunID,
+			run.TaskName,
 			string(run.Status),
 			run.CreatedAt.Format(time.RFC3339),
 			endedAt,


### PR DESCRIPTION
This PR adds support for a team-wide `airplane runs list`. The `--task` flag is now optional.

It also adds `paramValues`, `taskID`, and `taskName` to the JSON output of `airplane runs list -o json`.

```
❯ lairlocal runs list
          ID         |   TASK    |  STATUS   |        CREATED AT         |         ENDED AT
---------------------+-----------+-----------+---------------------------+----------------------------
  run20210811z14hqzf | Echo Loop | Succeeded | 2021-08-11T09:35:37-04:00 | 2021-08-11T09:36:04-04:00
  run20210811zo02z4m | Ping      | Succeeded | 2021-08-11T09:35:23-04:00 | 2021-08-11T09:35:27-04:00
```