### PR TITLE
Add `--since/--until` filtering to `runs list`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -37,6 +37,7 @@ require (
 	github.com/segmentio/backo-go v0.0.0-20200129164019-23eae7c10bd3 // indirect
 	github.com/segmentio/events/v2 v2.4.0
 	github.com/spf13/cobra v1.1.3
+	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.6.1
 	github.com/ulikunitz/xz v0.5.10 // indirect
 	github.com/xeipuuv/gojsonschema v1.2.0

--- a/pkg/api/client.go
+++ b/pkg/api/client.go
@@ -155,17 +155,18 @@ func (c Client) GetUniqueSlug(ctx context.Context, name, preferredSlug string) (
 }
 
 // ListRuns lists most recent runs.
-func (c Client) ListRuns(ctx context.Context, req ListRunsRequest) (resp ListRunsResponse, err error) {
+func (c Client) ListRuns(ctx context.Context, req ListRunsRequest) (ListRunsResponse, error) {
 	q := url.Values{}
 	q.Set("page", strconv.FormatInt(int64(req.Page), 10))
 	if req.TaskID != "" {
 		q.Set("taskID", req.TaskID)
 	}
-	limit := 100
-	if req.Limit != 0 {
-		limit = req.Limit
+	pageLimit := 100
+	if req.Limit > 0 && req.Limit < 100 {
+		// If a user provides a smaller limit, fetch exactly that many items.
+		pageLimit = req.Limit
 	}
-	q.Set("limit", strconv.FormatInt(int64(limit), 10))
+	q.Set("limit", strconv.FormatInt(int64(pageLimit), 10))
 	if !req.Since.IsZero() {
 		q.Set("since", req.Since.Format(time.RFC3339))
 	}
@@ -173,8 +174,33 @@ func (c Client) ListRuns(ctx context.Context, req ListRunsRequest) (resp ListRun
 		q.Set("until", req.Until.Format(time.RFC3339))
 	}
 
-	err = c.do(ctx, "GET", "/runs/list?"+q.Encode(), nil, &resp)
-	return
+	var resp ListRunsResponse
+	var page ListRunsResponse
+	var i int
+	for {
+		q["page"] = []string{strconv.FormatInt(int64(i), 10)}
+		i++
+		if err := c.do(ctx, "GET", "/runs/list?"+q.Encode(), nil, &page); err != nil {
+			return ListRunsResponse{}, err
+		}
+		runs := page.Runs
+		if req.Limit > 0 && len(resp.Runs)+len(runs) > req.Limit {
+			// Truncate the response if we over-fetched items:
+			runs = runs[:req.Limit-len(resp.Runs)]
+		}
+		resp.Runs = append(resp.Runs, runs...)
+
+		// There are no more items to fetch:
+		if len(page.Runs) != pageLimit {
+			break
+		}
+		// We have reached the requested limit of items to fetch:
+		if req.Limit > 0 && len(resp.Runs) == req.Limit {
+			break
+		}
+	}
+
+	return resp, nil
 }
 
 // RunTask runs a task.

--- a/pkg/api/client.go
+++ b/pkg/api/client.go
@@ -156,17 +156,22 @@ func (c Client) GetUniqueSlug(ctx context.Context, name, preferredSlug string) (
 
 // ListRuns lists most recent runs.
 func (c Client) ListRuns(ctx context.Context, req ListRunsRequest) (resp ListRunsResponse, err error) {
-	q := url.Values{
-		"page": []string{strconv.FormatInt(int64(req.Page), 10)},
-	}
+	q := url.Values{}
+	q.Set("page", strconv.FormatInt(int64(req.Page), 10))
 	if req.TaskID != "" {
-		q["taskID"] = []string{req.TaskID}
+		q.Set("taskID", req.TaskID)
 	}
 	limit := 100
 	if req.Limit != 0 {
 		limit = req.Limit
 	}
-	q["limit"] = []string{strconv.FormatInt(int64(limit), 10)}
+	q.Set("limit", strconv.FormatInt(int64(limit), 10))
+	if !req.Since.IsZero() {
+		q.Set("since", req.Since.Format(time.RFC3339))
+	}
+	if !req.Until.IsZero() {
+		q.Set("until", req.Until.Format(time.RFC3339))
+	}
 
 	err = c.do(ctx, "GET", "/runs/list?"+q.Encode(), nil, &resp)
 	return

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -390,9 +390,11 @@ type Run struct {
 
 // ListRunsRequest represents a list runs request.
 type ListRunsRequest struct {
-	TaskID string `json:"taskID"`
-	Page   int    `json:"page"`
-	Limit  int    `json:"limit"`
+	TaskID string    `json:"taskID"`
+	Since  time.Time `json:"since"`
+	Until  time.Time `json:"until"`
+	Page   int       `json:"page"`
+	Limit  int       `json:"limit"`
 }
 
 // ListRunsResponse represents a list runs response.

--- a/pkg/cmd/runs/list/list.go
+++ b/pkg/cmd/runs/list/list.go
@@ -39,8 +39,8 @@ func New(c *cli.Config) *cobra.Command {
 
 	cmd.Flags().StringVarP(&cfg.slug, "task", "t", "", "Filter runs by task slug")
 	cmd.Flags().IntVar(&cfg.limit, "limit", 100, "If >0, returns at most --limit items.")
-	cmd.Flags().Var(&cfg.since, "since", "Filter runs by the time they were created at")
-	cmd.Flags().Var(&cfg.until, "until", "Filter runs by the time they were created at")
+	cmd.Flags().Var(&cfg.since, "since", "Include only runs created after the given time")
+	cmd.Flags().Var(&cfg.until, "until", "Include only runs created before the given time")
 
 	return cmd
 }

--- a/pkg/cmd/runs/list/list.go
+++ b/pkg/cmd/runs/list/list.go
@@ -2,18 +2,26 @@ package list
 
 import (
 	"context"
+	"time"
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/airplanedev/cli/pkg/api"
 	"github.com/airplanedev/cli/pkg/cli"
 	"github.com/airplanedev/cli/pkg/print"
+	"github.com/airplanedev/cli/pkg/utils"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
+type config struct {
+	slug  string
+	since utils.TimeValue
+	until utils.TimeValue
+}
+
 // New returns a new list command.
 func New(c *cli.Config) *cobra.Command {
-	var slug string
+	var cfg config
 
 	cmd := &cobra.Command{
 		Use:   "list",
@@ -24,24 +32,29 @@ func New(c *cli.Config) *cobra.Command {
 			airplane runs list --task <slug> -o json
 		`),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return run(cmd.Root().Context(), c, slug)
+			return run(cmd.Root().Context(), c, cfg)
 		},
 	}
 
-	cmd.Flags().StringVarP(&slug, "task", "t", "", "Filter runs by task slug")
+	cmd.Flags().StringVarP(&cfg.slug, "task", "t", "", "Filter runs by task slug")
+	cmd.Flags().Var(&cfg.since, "since", "Filter runs by the time they were created at")
+	cmd.Flags().Var(&cfg.until, "until", "Filter runs by the time they were created at")
 
 	return cmd
 }
 
 // Run runs the list command.
-func run(ctx context.Context, c *cli.Config, slug string) error {
+func run(ctx context.Context, c *cli.Config, cfg config) error {
 	var client = c.Client
 
-	req := api.ListRunsRequest{}
+	req := api.ListRunsRequest{
+		Since: time.Time(cfg.since),
+		Until: time.Time(cfg.until),
+	}
 
 	// If a task slug was provided, look up its task ID:
-	if slug != "" {
-		task, err := client.GetTask(ctx, slug)
+	if cfg.slug != "" {
+		task, err := client.GetTask(ctx, cfg.slug)
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/runs/list/list.go
+++ b/pkg/cmd/runs/list/list.go
@@ -15,6 +15,7 @@ import (
 
 type config struct {
 	slug  string
+	limit int
 	since utils.TimeValue
 	until utils.TimeValue
 }
@@ -37,6 +38,7 @@ func New(c *cli.Config) *cobra.Command {
 	}
 
 	cmd.Flags().StringVarP(&cfg.slug, "task", "t", "", "Filter runs by task slug")
+	cmd.Flags().IntVar(&cfg.limit, "limit", 100, "If >0, returns at most --limit items.")
 	cmd.Flags().Var(&cfg.since, "since", "Filter runs by the time they were created at")
 	cmd.Flags().Var(&cfg.until, "until", "Filter runs by the time they were created at")
 
@@ -48,6 +50,7 @@ func run(ctx context.Context, c *cli.Config, cfg config) error {
 	var client = c.Client
 
 	req := api.ListRunsRequest{
+		Limit: cfg.limit,
 		Since: time.Time(cfg.since),
 		Until: time.Time(cfg.until),
 	}

--- a/pkg/utils/cobra.go
+++ b/pkg/utils/cobra.go
@@ -1,6 +1,12 @@
 package utils
 
-import "github.com/spf13/cobra"
+import (
+	"errors"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
 
 // WithParentPersistentPreRunE runs the parent command's PersistentPreRunE before the current
 // command's PersistentPreRunE. This prevents the default Cobra behavior of only running the
@@ -21,4 +27,53 @@ func WithParentPersistentPreRunE(f func(cmd *cobra.Command, args []string) error
 
 		return f(cmd, args)
 	}
+}
+
+// TimeValue is a pflag.Value that can be used to parse a time.Time
+// as a Cobra flag.
+//
+// For example:
+//   var tv timeValue
+//   cmd.Flags().Var(&tv, "since", "Filters by created_at")
+//
+// Which could be set as: `--since="2020-01-02 01:02:03"`
+//
+// TimeValue's are alias types of time.Time. You can convert safely via `time.Time(tv)`.
+type TimeValue time.Time
+
+var _ pflag.Value = &TimeValue{}
+
+func (tv *TimeValue) Set(s string) error {
+	for _, format := range []string{
+		// If a user does not specify a time zone, we interpret the time zone
+		// as local time:
+		"2006-01-02T15:04:05", // RFC339 without the "Z07:00"
+		// Otherwise, we look for a time zone.
+		time.RFC3339,
+	} {
+		v, err := time.ParseInLocation(format, s, time.Now().Location())
+		if err == nil {
+			*tv = TimeValue(v)
+			return nil
+		}
+	}
+
+	// If we did not find a match, return a helpful error message:
+	return errors.New("expected timestamp formatted as '2006-01-02T15:04:05' (local time) or '2006-01-02T15:04:05+07:00'")
+}
+
+func (tv *TimeValue) Type() string {
+	return "time"
+}
+
+func (tv *TimeValue) String() string {
+	if tv == nil {
+		return ""
+	}
+	t := time.Time(*tv)
+	if t.IsZero() {
+		return ""
+	}
+
+	return t.Format(time.RFC3339)
 }

--- a/pkg/utils/cobra.go
+++ b/pkg/utils/cobra.go
@@ -48,13 +48,18 @@ func (tv *TimeValue) Set(s string) error {
 	// https://github.com/spf13/cobra/issues/1114
 	// If fixed, we could start supporting time formats with spaces like "2006-01-02 15:04:05".
 	for _, format := range []string{
-		// If a user does not specify a time zone, we interpret the time zone
-		// as local time:
+		// Overall, we are roughly looking for RFC3339 timestamps with some leeway
+		// to make timestamps easier to specify.
+		//
+		// Local time zones:
 		"2006-01-02",
-		"2006-01-02T15:04:05", // RFC3339 without the "Z07:00"
-		// Otherwise, we look for a time zone.
-		time.RFC3339,
-		"2006-01-02T15:04:05Z0700", // RFC3339 without the timezone ":"
+		"2006-01-02T15:04",
+		"2006-01-02T15:04:05",
+		// Explicit time zones:
+		"2006-01-02T15:04Z07:00",
+		"2006-01-02T15:04Z0700",
+		"2006-01-02T15:04:05Z07:00", // time.RFC3339: copied for comparison with other formats
+		"2006-01-02T15:04:05Z0700",
 	} {
 		v, err := time.ParseInLocation(format, s, time.Now().Location())
 		if err == nil {

--- a/pkg/utils/cobra.go
+++ b/pkg/utils/cobra.go
@@ -36,7 +36,7 @@ func WithParentPersistentPreRunE(f func(cmd *cobra.Command, args []string) error
 //   var tv timeValue
 //   cmd.Flags().Var(&tv, "since", "Filters by created_at")
 //
-// Which could be set as: `--since="2020-01-02 01:02:03"`
+// Which could be set as: `--since="2020-01-02T01:02:03"`
 //
 // TimeValue's are alias types of time.Time. You can convert safely via `time.Time(tv)`.
 type TimeValue time.Time
@@ -44,9 +44,13 @@ type TimeValue time.Time
 var _ pflag.Value = &TimeValue{}
 
 func (tv *TimeValue) Set(s string) error {
+	// Cobra doesn't appear to support quoted strings with spaces:
+	// https://github.com/spf13/cobra/issues/1114
+	// If fixed, we could start supporting time formats with spaces like "2006-01-02 15:04:05".
 	for _, format := range []string{
 		// If a user does not specify a time zone, we interpret the time zone
 		// as local time:
+		"2006-01-02",
 		"2006-01-02T15:04:05", // RFC3339 without the "Z07:00"
 		// Otherwise, we look for a time zone.
 		time.RFC3339,
@@ -60,7 +64,7 @@ func (tv *TimeValue) Set(s string) error {
 	}
 
 	// If we did not find a match, return a helpful error message:
-	return errors.New("expected timestamp formatted as '2006-01-02T15:04:05' (local time) or '2006-01-02T15:04:05+07:00'")
+	return errors.New(`expected timestamp formatted as "2021-04-16" or "2021-04-16T01:30:59"`)
 }
 
 func (tv *TimeValue) Type() string {

--- a/pkg/utils/cobra.go
+++ b/pkg/utils/cobra.go
@@ -47,9 +47,10 @@ func (tv *TimeValue) Set(s string) error {
 	for _, format := range []string{
 		// If a user does not specify a time zone, we interpret the time zone
 		// as local time:
-		"2006-01-02T15:04:05", // RFC339 without the "Z07:00"
+		"2006-01-02T15:04:05", // RFC3339 without the "Z07:00"
 		// Otherwise, we look for a time zone.
 		time.RFC3339,
+		"2006-01-02T15:04:05Z0700", // RFC3339 without the timezone ":"
 	} {
 		v, err := time.ParseInLocation(format, s, time.Now().Location())
 		if err == nil {


### PR DESCRIPTION
This PR updates `runs list` s.t. you can optionally fetch all runs. It does this by introducing a `--since`, `--until`, and `--limit` flag. `--limit` defaults to `100`, but can be overridden to `0` (or any negative number) to fetch all runs. This can be optionally combined with `--since` and `--until` to filter by a time range.

For example, you could list all runs with:

```
airplane runs list --until $(date +%Y-%m-%dT%H:%M:%S%z) --limit=0
```

To support time-based flags, which cobra does not support out-of-the-box (!), I've added a `utils.TimeValue` which is a `pflag.Value`. This means you can use it with `cmd.Flags().Var(&timeValue, ...)`. It tries to be generous about parsing times and provide useful error messages.

The auto-pagination is a bit complicated. Would be a good use-case for generics!