### PR TITLE
Add handlebars.Render to fix accidental HTML-escaping

### DIFF
--- a/pkg/runtime/shell/shell.go
+++ b/pkg/runtime/shell/shell.go
@@ -14,7 +14,7 @@ import (
 	"github.com/airplanedev/cli/pkg/fsx"
 	"github.com/airplanedev/cli/pkg/logger"
 	"github.com/airplanedev/cli/pkg/runtime"
-	"github.com/aymerick/raymond"
+	"github.com/airplanedev/cli/pkg/utils/handlebars"
 	"github.com/pkg/errors"
 )
 
@@ -75,7 +75,7 @@ func (r Runtime) PrepareRun(ctx context.Context, opts runtime.PrepareRunOptions)
 	// TODO: this is a rough approximation of how interpolateParameters works in prod
 	for slug, _ := range opts.ParamValues {
 		tmpl := fmt.Sprintf("%s={{%s}}", slug, slug)
-		val, err := raymond.Render(tmpl, opts.ParamValues)
+		val, err := handlebars.Render(tmpl, opts.ParamValues)
 		if err != nil {
 			return nil, errors.Wrap(err, "rendering shell command")
 		}

--- a/pkg/utils/handlebars/handlebars.go
+++ b/pkg/utils/handlebars/handlebars.go
@@ -1,0 +1,20 @@
+// Light wrapper around handlebars.
+// Temporary replacement until we switch to full JS evaluation.
+package handlebars
+
+import "github.com/aymerick/raymond"
+
+// Render is an Airplane-customized handlebars renderer. Primarily, it assumes we're interpolating
+// for non-html contexts like run parameters and does not perform HTML-escaping.
+func Render(source string, ctx map[string]interface{}) (string, error) {
+	// Because we're not using this for HTML, treat all string values as safe.
+	vals := map[string]interface{}{}
+	for k, v := range ctx {
+		if s, ok := v.(string); ok {
+			vals[k] = raymond.SafeString(s)
+		} else {
+			vals[k] = v
+		}
+	}
+	return raymond.Render(source, vals)
+}


### PR DESCRIPTION
We don't use handlebars for HTML templates, so this adds our own
handlebars library to mark as strings as safe. Only used by shell
builder in this repository.
