### PR TITLE
Remove templating from shell shim

### DIFF
--- a/pkg/build/shell-shim.sh
+++ b/pkg/build/shell-shim.sh
@@ -2,7 +2,7 @@
 
 # Params are based in as param_slug_1=value1, param_slug_2=value2
 # Export as environment varaibles, PARAM_SLUG_1=value1, PARAM_SLUG_2=value2
-for param in "$@"; do
+for param in "${@:2}"; do
     param_slug="$(cut -d '=' -f 1 <<< "${param}")"
     param_value="$(cut -d '=' -f 2 <<< "${param}")"
     # Convert to uppercase
@@ -11,4 +11,4 @@ for param in "$@"; do
     export "${var_name}"="${param_value}"
 done
 
-exec "{{ .Entrypoint }}"
+exec "$1"

--- a/pkg/build/shell.go
+++ b/pkg/build/shell.go
@@ -21,11 +21,6 @@ func shell(root string, options api.KindOptions) (string, error) {
 		return "", err
 	}
 
-	shim, err := ShellShim(entrypoint)
-	if err != nil {
-		return "", err
-	}
-
 	// Build off of the dockerfile if provided:
 	var dockerfileTemplate string
 	if dockerfilePath := FindDockerfile(root); dockerfilePath != "" {
@@ -75,13 +70,13 @@ func shell(root string, options api.KindOptions) (string, error) {
 		COPY . .
 		RUN chmod +x {{.Entrypoint}}
 		
-		ENTRYPOINT ["bash", ".airplane/shim.sh"]
+		ENTRYPOINT ["bash", ".airplane/shim.sh", "/airplane/{{.Entrypoint}}"]
 	`)
 	return applyTemplate(dockerfileTemplate, struct {
 		InlineShim string
 		Entrypoint string
 	}{
-		InlineShim: inlineString(shim),
+		InlineShim: inlineString(ShellShim()),
 		Entrypoint: backslashEscape(entrypoint, `"`),
 	})
 }
@@ -89,19 +84,8 @@ func shell(root string, options api.KindOptions) (string, error) {
 //go:embed shell-shim.sh
 var shellShim string
 
-func ShellShim(entrypoint string) (string, error) {
-	// exec needs a relative path
-	entrypoint = "./" + filepath.Clean(entrypoint)
-	shim, err := applyTemplate(shellShim, struct {
-		Entrypoint string
-	}{
-		Entrypoint: entrypoint,
-	})
-	if err != nil {
-		return "", errors.Wrap(err, "templating shim")
-	}
-
-	return shim, nil
+func ShellShim() string {
+	return shellShim
 }
 
 // FindDockerfile looks for variants of supported Dockerfile locations and returns non-empty path

--- a/pkg/runtime/shell/shell.go
+++ b/pkg/runtime/shell/shell.go
@@ -58,20 +58,20 @@ func (r Runtime) PrepareRun(ctx context.Context, opts runtime.PrepareRunOptions)
 		return nil, errors.Wrap(err, "creating .airplane directory")
 	}
 
-	entrypoint, err := filepath.Rel(root, opts.Path)
-	if err != nil {
-		return nil, errors.Wrap(err, "entrypoint is not within the task root")
-	}
-	shim, err := build.ShellShim(entrypoint)
-	if err != nil {
-		return nil, err
-	}
-
+	shim := build.ShellShim()
 	if err := os.WriteFile(filepath.Join(root, ".airplane/shim.sh"), []byte(shim), 0644); err != nil {
 		return nil, errors.Wrap(err, "writing shim file")
 	}
 
-	cmd := []string{"bash", filepath.Join(root, ".airplane/shim.sh")}
+	entrypoint, err := filepath.Rel(root, opts.Path)
+	if err != nil {
+		return nil, errors.Wrap(err, "entrypoint is not within the task root")
+	}
+
+	cmd := []string{
+		"bash", filepath.Join(root, ".airplane/shim.sh"),
+		filepath.Join(root, entrypoint),
+	}
 	// TODO: this is a rough approximation of how interpolateParameters works in prod
 	for slug, _ := range opts.ParamValues {
 		tmpl := fmt.Sprintf("%s={{%s}}", slug, slug)


### PR DESCRIPTION
Simplify shim by making it static - the entrypoint is passed as the
first argument instead.

Makes it slightly easier to reason about for e.g. ruby scripts - the
shell shim is an exec wrapper (does some setup and then execs through to
the original entrypoint).
