### PR TITLE
Fix shell to detect Dockerfile.airplane for root

### DIFF
--- a/pkg/build/shell.go
+++ b/pkg/build/shell.go
@@ -8,6 +8,7 @@ import (
 	"github.com/MakeNowJust/heredoc"
 	"github.com/airplanedev/cli/pkg/api"
 	"github.com/airplanedev/cli/pkg/fsx"
+	"github.com/airplanedev/cli/pkg/logger"
 	"github.com/pkg/errors"
 )
 
@@ -104,15 +105,21 @@ func ShellShim(entrypoint string) (string, error) {
 	return shim, nil
 }
 
+func DockerfilePaths() []string {
+	return []string{
+		"Dockerfile.airplane",
+		"Dockerfile",
+	}
+}
+
 // FindDockerfile looks for variants of supported Dockerfile locations and returns non-empty path
 // to the file, if found.
 func FindDockerfile(root string) string {
-	for _, filePath := range []string{
-		"Dockerfile.airplane",
-		"Dockerfile",
-	} {
+	for _, filePath := range DockerfilePaths() {
+		logger.Debug("looking for %q", filePath)
 		dockerfilePath := filepath.Join(root, filePath)
 		if fsx.Exists(dockerfilePath) {
+			logger.Debug("found %q", dockerfilePath)
 			return dockerfilePath
 		}
 	}

--- a/pkg/runtime/shell/shell.go
+++ b/pkg/runtime/shell/shell.go
@@ -103,11 +103,12 @@ func (r Runtime) Workdir(path string) (string, error) {
 
 // Root implementation.
 func (r Runtime) Root(path string) (string, error) {
-	root, ok := fsx.Find(path, "Dockerfile")
-	if !ok {
-		return filepath.Dir(path), nil
+	for _, filePath := range build.DockerfilePaths() {
+		if root, ok := fsx.Find(path, filePath); ok {
+			return root, nil
+		}
 	}
-	return root, nil
+	return filepath.Dir(path), nil
 }
 
 // Kind implementation.


### PR DESCRIPTION
Shell was using Dockerfile.airplane if it happened to be in the root,
but to detect the root itself it was only looking for Dockerfile.
Meaning, unless the root somehow accidentally was right due to another
Dockerfile present or it was the same directory as the script,
Dockerfile.airplane wasn't being used.
