### PR TITLE
Loosen default airplane ignores

### DIFF
--- a/pkg/build/ignore/ignore.go
+++ b/pkg/build/ignore/ignore.go
@@ -67,8 +67,10 @@ func Patterns(path string) ([]string, error) {
 	// https://github.com/github/gitignore
 	// https://github.com/github/gitignore/blob/master/Go.gitignore
 	// https://github.com/github/gitignore/blob/master/Node.gitignore
+	// https://vercel.com/docs/build-step#ignored-files-and-folders
 	excludes := []string{
-		"*.env",
+		".env.local",
+		".env.*.local",
 		"*.pyc",
 		".git",
 		".gitmodules",
@@ -78,15 +80,14 @@ func Patterns(path string) ([]string, error) {
 		".now",
 		".npm",
 		".svn",
+		".*.swp",
 		".terraform",
 		".venv",
+		".vercel",
 		".yarn",
 		"__pycache__",
-		"bin",
-		"dist",
 		"node_modules",
 		"npm-debug.log",
-		"out",
 		// Local build artifacts created by `airplane dev`.
 		".airplane",
 	}


### PR DESCRIPTION
This was triggered by bin/ being ignored for rails, which causes `rails
runner` and other commands to not work. (Rails has some magic where it
looks for and runs the local bin/).

In hindsight, I think ignoring some of these (e.g. *.env) was too
aggressive, and we should only ignore the ones that are known to be not
necessary (or dangerous even) to include in builds.
