### PR TITLE
Improve runtime detection to favor task kind

### DIFF
--- a/pkg/cmd/tasks/deploy/script.go
+++ b/pkg/cmd/tasks/deploy/script.go
@@ -20,32 +20,22 @@ import (
 // DeployFromScript deploys from the given script.
 func deployFromScript(ctx context.Context, cfg config) (rErr error) {
 	client := cfg.client
-	ext := filepath.Ext(cfg.file)
-	props := taskDeployedProps{
+	tp := taskDeployedProps{
 		from: "script",
 	}
 	start := time.Now()
 	defer func() {
 		analytics.Track(cfg.root, "Task Deployed", map[string]interface{}{
-			"from":             props.from,
-			"kind":             props.kind,
-			"task_id":          props.taskID,
-			"task_slug":        props.taskSlug,
-			"task_name":        props.taskName,
-			"build_id":         props.buildID,
+			"from":             tp.from,
+			"kind":             tp.kind,
+			"task_id":          tp.taskID,
+			"task_slug":        tp.taskSlug,
+			"task_name":        tp.taskName,
+			"build_id":         tp.buildID,
 			"errored":          rErr != nil,
 			"duration_seconds": time.Since(start).Seconds(),
 		})
 	}()
-
-	if ext == "" {
-		return errors.New("cannot deploy a file without extension")
-	}
-
-	r, ok := runtime.Lookup(cfg.file)
-	if !ok {
-		return errors.Errorf("cannot deploy a file with extension of %q", ext)
-	}
 
 	code, err := ioutil.ReadFile(cfg.file)
 	if err != nil {
@@ -61,13 +51,14 @@ func deployFromScript(ctx context.Context, cfg config) (rErr error) {
 	if err != nil {
 		return err
 	}
-	props.kind = task.Kind
-	props.taskID = task.ID
-	props.taskSlug = task.Slug
-	props.taskName = task.Name
+	tp.kind = task.Kind
+	tp.taskID = task.ID
+	tp.taskSlug = task.Slug
+	tp.taskName = task.Name
 
-	if task.Kind != r.Kind() {
-		return errors.Errorf("'%s' is a %s task. Expected a %s task.", task.Name, task.Kind, r.Kind())
+	r, ok := runtime.Lookup(task.Kind, cfg.file)
+	if !ok {
+		return errors.Errorf("cannot determine how to deploy %q - check your CLI is up to date", cfg.file)
 	}
 
 	def, err := definitions.NewDefinitionFromTask(task)
@@ -105,7 +96,7 @@ func deployFromScript(ctx context.Context, cfg config) (rErr error) {
 		return err
 	}
 
-	props.buildLocal = cfg.local
+	tp.buildLocal = cfg.local
 	resp, err := build.Run(ctx, build.Request{
 		Local:   cfg.local,
 		Client:  client,
@@ -118,7 +109,7 @@ func deployFromScript(ctx context.Context, cfg config) (rErr error) {
 	if err != nil {
 		return err
 	}
-	props.buildID = resp.BuildID
+	tp.buildID = resp.BuildID
 
 	_, err = client.UpdateTask(ctx, api.UpdateTaskRequest{
 		Slug:                       def.Slug,

--- a/pkg/cmd/tasks/deploy/script.go
+++ b/pkg/cmd/tasks/deploy/script.go
@@ -56,9 +56,9 @@ func deployFromScript(ctx context.Context, cfg config) (rErr error) {
 	tp.taskSlug = task.Slug
 	tp.taskName = task.Name
 
-	r, ok := runtime.Lookup(task.Kind, cfg.file)
-	if !ok {
-		return errors.Errorf("cannot determine how to deploy %q - check your CLI is up to date", cfg.file)
+	r, err := runtime.Lookup(task.Kind, cfg.file)
+	if err != nil {
+		return errors.Wrapf(err, "cannot determine how to deploy %q - check your CLI is up to date", cfg.file)
 	}
 
 	def, err := definitions.NewDefinitionFromTask(task)

--- a/pkg/cmd/tasks/dev/dev.go
+++ b/pkg/cmd/tasks/dev/dev.go
@@ -80,9 +80,9 @@ func run(ctx context.Context, cfg config) error {
 		return errors.Wrap(err, "getting task")
 	}
 
-	r, ok := runtime.Lookup(cfg.file)
+	r, ok := runtime.Lookup(task.Kind, cfg.file)
 	if !ok {
-		return errors.Errorf("Unsupported file type: %s", filepath.Base(cfg.file))
+		return errors.Errorf("unsupported file type: %s", filepath.Base(cfg.file))
 	}
 
 	paramValues, err := params.CLI(cfg.args, cfg.root.Client, task)
@@ -220,7 +220,7 @@ func getDevEnv(r runtime.Interface, path string) (map[string]string, error) {
 	return env, errors.Wrap(err, "reading .env")
 }
 
-// slugFromScript attempts to extract a slug from a script.
+// slugFromScript attempts to extract a slug from a file based on its contents.
 func slugFromScript(file string) (string, error) {
 	code, err := ioutil.ReadFile(file)
 	if err != nil {

--- a/pkg/cmd/tasks/dev/dev.go
+++ b/pkg/cmd/tasks/dev/dev.go
@@ -80,9 +80,9 @@ func run(ctx context.Context, cfg config) error {
 		return errors.Wrap(err, "getting task")
 	}
 
-	r, ok := runtime.Lookup(task.Kind, cfg.file)
-	if !ok {
-		return errors.Errorf("unsupported file type: %s", filepath.Base(cfg.file))
+	r, err := runtime.Lookup(task.Kind, cfg.file)
+	if err != nil {
+		return errors.Wrapf(err, "unsupported file type: %s", filepath.Base(cfg.file))
 	}
 
 	paramValues, err := params.CLI(cfg.args, cfg.root.Client, task)

--- a/pkg/cmd/tasks/execute/execute.go
+++ b/pkg/cmd/tasks/execute/execute.go
@@ -159,13 +159,8 @@ func slugFrom(file string) (string, error) {
 	switch ext := filepath.Ext(file); ext {
 	case ".yml", ".yaml":
 		return slugFromYaml(file)
-	case "":
-		return "", fmt.Errorf("the file %s must have an extension", file)
 	default:
-		if _, ok := runtime.Lookup(file); ok {
-			return slugFromScript(file)
-		}
-		return "", fmt.Errorf("the file %s has unrecognized extension", file)
+		return slugFromScript(file)
 	}
 }
 

--- a/pkg/cmd/tasks/initcmd/init.go
+++ b/pkg/cmd/tasks/initcmd/init.go
@@ -81,13 +81,9 @@ func run(ctx context.Context, cfg config) error {
 		}
 	}
 
-	r, ok := runtime.Lookup(task.Kind, cfg.file)
-	if !ok {
-		return errors.Errorf("unable to init %q - check that your CLI is up to date", cfg.file)
-	}
-
-	if task.Kind != r.Kind() {
-		return errors.Errorf("cannot link %q to a %s task", cfg.file, task.Kind)
+	r, err := runtime.Lookup(task.Kind, cfg.file)
+	if err != nil {
+		return errors.Wrapf(err, "unable to init %q - check that your CLI is up to date", cfg.file)
 	}
 
 	if fsx.Exists(cfg.file) {

--- a/pkg/cmd/tasks/initcmd/init.go
+++ b/pkg/cmd/tasks/initcmd/init.go
@@ -81,14 +81,9 @@ func run(ctx context.Context, cfg config) error {
 		}
 	}
 
-	ext := filepath.Ext(cfg.file)
-	if ext == "" {
-		return errors.Errorf("expected <path> %q to have a file extension", cfg.file)
-	}
-
-	r, ok := runtime.Lookup(cfg.file)
+	r, ok := runtime.Lookup(task.Kind, cfg.file)
 	if !ok {
-		return errors.Errorf("unable to deploy task with %q file extension", ext)
+		return errors.Errorf("unable to init %q - check that your CLI is up to date", cfg.file)
 	}
 
 	if task.Kind != r.Kind() {

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -107,12 +107,8 @@ func Register(ext string, r Interface) {
 // Lookup returns a runtime by kind and path.
 // If an extension match is found, use that runtime. Otherwise rely on the task kind.
 func Lookup(kind api.TaskKind, path string) (Interface, bool) {
-	type match struct {
-		ext string
-		r   Interface
-	}
 	pathExt := filepath.Ext(path)
-	possible := []match{}
+	possible := []Interface{}
 	for ext, runtime := range runtimes {
 		if runtime.Kind() != kind {
 			continue
@@ -120,12 +116,12 @@ func Lookup(kind api.TaskKind, path string) (Interface, bool) {
 		if pathExt == ext {
 			return runtime, true
 		}
-		possible = append(possible, match{ext, runtime})
+		possible = append(possible, runtime)
 	}
 	if len(possible) != 1 {
 		return nil, false
 	}
-	return possible[0].r, true
+	return possible[0], true
 }
 
 // SuggestExt returns the default extension for a given TaskKind, if any.


### PR DESCRIPTION
Rather than solely base it off of extension, determine runtime by
figuring out the task kind first. In some cases, like TS/JS, the exact
runtime will depend on the extension.

This allows using e.g. some_task.rb with shell script, since some_task
can already be created with kind=shell.
