### PR TITLE
Set `BuildID` from `airplane deploy`

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -46,7 +46,8 @@ type UpdateTaskRequest struct {
 	RequireExplicitPermissions bool              `json:"requireExplicitPermissions" yaml:"-"`
 	Permissions                Permissions       `json:"permissions" yaml:"-"`
 	// TODO(amir): friendly type here (120s, 5m ...)
-	Timeout int `json:"timeout" yaml:"timeout"`
+	Timeout int     `json:"timeout" yaml:"timeout"`
+	BuildID *string `json:"buildID" yaml:"-"`
 }
 
 type Permissions []Permission

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -29,25 +29,25 @@ type CreateTaskRequest struct {
 
 // UpdateTaskRequest updates a task.
 type UpdateTaskRequest struct {
-	Slug                       string            `json:"slug" yaml:"-"`
-	Name                       string            `json:"name" yaml:"name"`
-	Description                string            `json:"description" yaml:"description"`
-	Image                      *string           `json:"image" yaml:"image"`
-	Command                    []string          `json:"command" yaml:"command"`
-	Arguments                  []string          `json:"arguments" yaml:"arguments"`
-	Parameters                 Parameters        `json:"parameters" yaml:"parameters"`
-	Constraints                RunConstraints    `json:"constraints" yaml:"constraints"`
-	Env                        TaskEnv           `json:"env" yaml:"env"`
-	ResourceRequests           map[string]string `json:"resourceRequests" yaml:"resourceRequests"`
-	Resources                  map[string]string `json:"resources" yaml:"resources"`
-	Kind                       TaskKind          `json:"kind" yaml:"builder"`
-	KindOptions                KindOptions       `json:"kindOptions" yaml:"builderConfig"`
-	Repo                       string            `json:"repo" yaml:"repo"`
-	RequireExplicitPermissions bool              `json:"requireExplicitPermissions" yaml:"-"`
-	Permissions                Permissions       `json:"permissions" yaml:"-"`
+	Slug                       string            `json:"slug"`
+	Name                       string            `json:"name"`
+	Description                string            `json:"description"`
+	Image                      *string           `json:"image"`
+	Command                    []string          `json:"command"`
+	Arguments                  []string          `json:"arguments"`
+	Parameters                 Parameters        `json:"parameters"`
+	Constraints                RunConstraints    `json:"constraints"`
+	Env                        TaskEnv           `json:"env"`
+	ResourceRequests           map[string]string `json:"resourceRequests"`
+	Resources                  map[string]string `json:"resources"`
+	Kind                       TaskKind          `json:"kind"`
+	KindOptions                KindOptions       `json:"kindOptions"`
+	Repo                       string            `json:"repo"`
+	RequireExplicitPermissions bool              `json:"requireExplicitPermissions"`
+	Permissions                Permissions       `json:"permissions"`
 	// TODO(amir): friendly type here (120s, 5m ...)
-	Timeout int     `json:"timeout" yaml:"timeout"`
-	BuildID *string `json:"buildID" yaml:"-"`
+	Timeout int     `json:"timeout"`
+	BuildID *string `json:"buildID"`
 }
 
 type Permissions []Permission

--- a/pkg/cmd/tasks/deploy/script.go
+++ b/pkg/cmd/tasks/deploy/script.go
@@ -14,6 +14,7 @@ import (
 	"github.com/airplanedev/cli/pkg/logger"
 	"github.com/airplanedev/cli/pkg/runtime"
 	"github.com/airplanedev/cli/pkg/taskdir/definitions"
+	"github.com/airplanedev/cli/pkg/utils/pointers"
 	"github.com/pkg/errors"
 )
 
@@ -129,6 +130,7 @@ func deployFromScript(ctx context.Context, cfg config) (rErr error) {
 		RequireExplicitPermissions: task.RequireExplicitPermissions,
 		Permissions:                task.Permissions,
 		Timeout:                    def.Timeout,
+		BuildID:                    pointers.String(resp.BuildID),
 	})
 	if err != nil {
 		return err

--- a/pkg/utils/pointers/pointers.go
+++ b/pkg/utils/pointers/pointers.go
@@ -3,3 +3,10 @@ package pointers
 func Bool(b bool) *bool {
 	return &b
 }
+
+func String(s string) *string {
+	if s == "" {
+		return nil
+	}
+	return &s
+}


### PR DESCRIPTION
This PR updates `airplane deploy` to set the `buildID` field after running a remote build, at the same point at which it sets the `Image`. This will be used to show build metadata for tasks and runs.