### PR TITLE
Fix build issue with Node builder

### DIFF
--- a/pkg/build/node.go
+++ b/pkg/build/node.go
@@ -106,7 +106,7 @@ func node(root string, options api.KindOptions) (string, error) {
 
 		RUN mkdir -p /airplane/.airplane && \
 			cd /airplane/.airplane && \
-			echo '{{.InlineShimPackageJSON}}' > package.json && \
+			{{.InlineShimPackageJSON}} > package.json && \
 			npm install
 
 		{{if not .HasPackageJSON}}


### PR DESCRIPTION
Our `inlineString` method already wraps the string with `echo '...'`. It currently errors as:

```
[build] npm ERR! code EJSONPARSE
[build] npm ERR! path /airplane/.airplane/package.json
[build] npm ERR! JSON.parse Unexpected token "e" (0x65) in JSON at position 0 while parsing near "echo {dependencies:{..."
[build] npm ERR! JSON.parse Failed to parse JSON data.
[build] npm ERR! JSON.parse Note: package.json must be actual JSON, not just JavaScript.
```