### PR TITLE
Fix filepaths on windows

### DIFF
--- a/pkg/build/remote.go
+++ b/pkg/build/remote.go
@@ -100,7 +100,7 @@ func updateKindAndOptions(ctx context.Context, client *api.Client, def definitio
 
 	// Normalize entrypoint to `/` regardless of OS.
 	if ep, ok := kindOptions["entrypoint"].(string); ok {
-		kindOptions["entrypoint"] = filepath.Clean(filepath.ToSlash(ep))
+		kindOptions["entrypoint"] = filepath.ToSlash(filepath.Clean(ep))
 	}
 
 	_, err = client.UpdateTask(ctx, api.UpdateTaskRequest{

--- a/pkg/fsx/fsx.go
+++ b/pkg/fsx/fsx.go
@@ -49,7 +49,7 @@ func FindUntil(start, end, filename string) (string, bool) {
 
 	if !Exists(dst) {
 		next := filepath.Dir(start)
-		if next == "." || (end != "" && strings.HasPrefix(end, next)) || next == string(filepath.Separator) {
+		if next == start || next == "." || (end != "" && strings.HasPrefix(end, next)) || next == string(filepath.Separator) {
 			return "", false
 		}
 		return FindUntil(next, end, filename)


### PR DESCRIPTION
Turns out that `filepath.Clean()` undoes the work of `filepath.ToSlash()`. Also adds in something to avoid infinite-recursion on some Windows systems where the root is `C:\` or something along those lines rather than the empty string