### PR TITLE
Fix httpd cancellation for processes that contain children

### DIFF
--- a/pkg/httpd/cmdexecutor.go
+++ b/pkg/httpd/cmdexecutor.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
-	"os/signal"
 	"sync"
 	"syscall"
 	"time"
@@ -26,6 +25,7 @@ func GetCmd(cmd string, args []string, env map[string]interface{}) *exec.Cmd {
 	// Set up command to run and arguments.
 	execCmd := exec.Command(cmd, args...)
 	execCmd.Env = os.Environ()
+	execCmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	for k, v := range env {
 		execCmd.Env = append(execCmd.Env, fmt.Sprintf("%s=%s", k, v))
 	}
@@ -95,13 +95,12 @@ func (c *CmdExecutorManager) DeleteExecutor(executionID *string) error {
 type CmdExecutor struct {
 	ActiveCmd      *exec.Cmd
 	ActiveCmdMutex *sync.Mutex
-	SignalC        chan os.Signal
+	SignalC        chan syscall.Signal
 	ExecutionID    string
 }
 
 func newCmdExecutor(executionID string) *CmdExecutor {
-	signalC := make(chan os.Signal, 1)
-	signal.Notify(signalC, os.Interrupt, syscall.SIGINT, syscall.SIGTERM)
+	signalC := make(chan syscall.Signal, 1)
 	mutex := sync.Mutex{}
 	return &CmdExecutor{
 		ActiveCmd:      nil,
@@ -141,8 +140,9 @@ func (c *CmdExecutor) Run(outputC <-chan Output, outputDoneC <-chan interface{},
 			if !c.hasActiveProcess() {
 				return errors.New("unable to signal, command already exited")
 			}
-			if err := c.ActiveCmd.Process.Signal(signal); err != nil {
-				return errors.Wrap(err, "unable to signal, command already exited")
+			// Kill all processes in the process group by sending signal to -pid.
+			if err := syscall.Kill(-c.ActiveCmd.Process.Pid, signal); err != nil {
+				return errors.Wrap(err, fmt.Sprintf("unable to signal: %s", c.ExecutionID))
 			}
 		case output := <-outputC:
 			if err := encoder.Encode(output); err != nil {


### PR DESCRIPTION
## Description
Before, shell scripts were unable to be correctly terminated since they spawn child processes and we were only killing the parent process. This change changes the kill logic to kill the entire process group.

## Test plan
Ran locally with a shell script and confirmed it terminated correctly
