### PR TITLE
Add methods to log with current time and use in httpd

### DIFF
--- a/pkg/cmd/serve/serve.go
+++ b/pkg/cmd/serve/serve.go
@@ -14,11 +14,12 @@ import (
 
 // Config is the httpd config.
 type config struct {
-	root *cli.Config
-	host string
-	port int
-	cmd  string
-	args []string
+	root        *cli.Config
+	host        string
+	port        int
+	cmd         string
+	parallelism int
+	args        []string
 }
 
 const (
@@ -30,7 +31,7 @@ func New(c *cli.Config) *cobra.Command {
 	var cfg = config{root: c}
 
 	cmd := &cobra.Command{
-		Use:   "serve cmd... [--port] [--host]",
+		Use:   "serve cmd... [--port] [--host] [--parallelism]",
 		Short: "Start the Airplane runtime.",
 		Long:  "Start an http server that implements the Airplane runtime.",
 		Example: heredoc.Doc(`
@@ -51,6 +52,7 @@ func New(c *cli.Config) *cobra.Command {
 	cmd.Flags().IntVar(&cfg.port, "port", defaultPort, "port to run listen on")
 	// Unless localhost is specified, MacOS with firewall on will ask for approval every time server starts
 	cmd.Flags().StringVar(&cfg.host, "host", "", "host to listen on")
+	cmd.Flags().IntVar(&cfg.parallelism, "parallelism", 1, "how many concurrent processes can be started")
 	// Hide this command until it's ready.
 	cmd.Hidden = true
 	return cmd
@@ -58,11 +60,20 @@ func New(c *cli.Config) *cobra.Command {
 
 // Run runs the execute command.
 func run(ctx context.Context, cfg config) error {
+	// Keep track of the maximum number of parallel processes.
+	slots := make(chan interface{}, cfg.parallelism)
+	for i := 0; i < cfg.parallelism; i++ {
+		slots <- true
+	}
+	serverDoneC := make(chan interface{})
 	return httpd.ServeWithGracefulShutdown(
 		ctx,
 		&http.Server{
 			Addr:    fmt.Sprintf("%s:%d", cfg.host, cfg.port),
-			Handler: httpd.Route(cfg.cmd, cfg.args),
+			Handler: httpd.Route(cfg.cmd, cfg.args, slots, serverDoneC),
 		},
+		cfg.parallelism,
+		slots,
+		serverDoneC,
 	)
 }

--- a/pkg/httpd/cmdexecutor.go
+++ b/pkg/httpd/cmdexecutor.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
-	"os/signal"
 	"sync"
 	"syscall"
 	"time"
@@ -26,6 +25,7 @@ func GetCmd(cmd string, args []string, env map[string]interface{}) *exec.Cmd {
 	// Set up command to run and arguments.
 	execCmd := exec.Command(cmd, args...)
 	execCmd.Env = os.Environ()
+	execCmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	for k, v := range env {
 		execCmd.Env = append(execCmd.Env, fmt.Sprintf("%s=%s", k, v))
 	}
@@ -95,13 +95,12 @@ func (c *CmdExecutorManager) DeleteExecutor(executionID *string) error {
 type CmdExecutor struct {
 	ActiveCmd      *exec.Cmd
 	ActiveCmdMutex *sync.Mutex
-	SignalC        chan os.Signal
+	SignalC        chan syscall.Signal
 	ExecutionID    string
 }
 
 func newCmdExecutor(executionID string) *CmdExecutor {
-	signalC := make(chan os.Signal, 1)
-	signal.Notify(signalC, os.Interrupt, syscall.SIGINT, syscall.SIGTERM)
+	signalC := make(chan syscall.Signal, 1)
 	mutex := sync.Mutex{}
 	return &CmdExecutor{
 		ActiveCmd:      nil,
@@ -141,8 +140,9 @@ func (c *CmdExecutor) Run(outputC <-chan Output, outputDoneC <-chan interface{},
 			if !c.hasActiveProcess() {
 				return errors.New("unable to signal, command already exited")
 			}
-			if err := c.ActiveCmd.Process.Signal(signal); err != nil {
-				return errors.Wrap(err, "unable to signal, command already exited")
+			// Kill all processes in the process group by sending signal to -pid.
+			if err := syscall.Kill(-c.ActiveCmd.Process.Pid, signal); err != nil {
+				return errors.Wrap(err, fmt.Sprintf("unable to signal: %s", c.ExecutionID))
 			}
 		case output := <-outputC:
 			if err := encoder.Encode(output); err != nil {

--- a/pkg/httpd/server_test.go
+++ b/pkg/httpd/server_test.go
@@ -44,11 +44,13 @@ func parseOutputs(s string, require *require.Assertions) []Output {
 
 func TestExecuteCmdSimpleEcho(t *testing.T) {
 	require := require.New(t)
-
+	slots := make(chan interface{}, 1)
+	slots <- true
+	serverDoneC := make(chan interface{})
 	h := getHttpExpect(
 		context.Background(),
 		t,
-		Route("echo", []string{"hello"}),
+		Route("echo", []string{"hello"}, serverDoneC, slots),
 	)
 	body := h.POST("/execute").
 		WithJSON(map[string]interface{}{}).
@@ -69,6 +71,9 @@ func TestExecuteCmdSimpleEcho(t *testing.T) {
 
 func TestExecuteCmdLongPrint(t *testing.T) {
 	require := require.New(t)
+	slots := make(chan interface{}, 1)
+	slots <- true
+	serverDoneC := make(chan interface{})
 
 	// Check that long output finishes correctly.
 	const numOutputs = 1000
@@ -80,7 +85,7 @@ func TestExecuteCmdLongPrint(t *testing.T) {
 	h := getHttpExpect(
 		context.Background(),
 		t,
-		Route("printf", []string{}),
+		Route("printf", []string{}, slots, serverDoneC),
 	)
 	body := h.POST("/execute").
 		WithJSON(ExecuteCmdRequest{
@@ -97,11 +102,14 @@ func TestExecuteCmdLongPrint(t *testing.T) {
 
 func TestExecuteCmdError(t *testing.T) {
 	require := require.New(t)
+	slots := make(chan interface{}, 1)
+	slots <- true
+	serverDoneC := make(chan interface{})
 
 	h := getHttpExpect(
 		context.Background(),
 		t,
-		Route("nonexistingbinary", []string{""}),
+		Route("nonexistingbinary", []string{""}, slots, serverDoneC),
 	)
 	body := h.POST("/execute").
 		WithJSON(map[string]interface{}{}).
@@ -118,11 +126,14 @@ func TestExecuteCmdError(t *testing.T) {
 
 func TestExecuteCmdExitError(t *testing.T) {
 	require := require.New(t)
+	slots := make(chan interface{}, 1)
+	slots <- true
+	serverDoneC := make(chan interface{})
 
 	h := getHttpExpect(
 		context.Background(),
 		t,
-		Route("grep", []string{""}),
+		Route("grep", []string{""}, slots, serverDoneC),
 	)
 	body := h.POST("/execute").
 		WithJSON(ExecuteCmdRequest{
@@ -144,11 +155,14 @@ func TestExecuteCmdExitError(t *testing.T) {
 }
 func TestExecuteCmdEnv(t *testing.T) {
 	require := require.New(t)
+	slots := make(chan interface{}, 1)
+	slots <- true
+	serverDoneC := make(chan interface{})
 
 	h := getHttpExpect(
 		context.Background(),
 		t,
-		Route("env", []string{}),
+		Route("env", []string{}, slots, serverDoneC),
 	)
 	body := h.POST("/execute").
 		WithJSON(ExecuteCmdRequest{
@@ -168,6 +182,9 @@ func TestExecuteCmdEnv(t *testing.T) {
 func TestExecuteCmdContextCancel(t *testing.T) {
 	require := require.New(t)
 	ctx, cancel := context.WithCancel(context.Background())
+	slots := make(chan interface{}, 1)
+	slots <- true
+	serverDoneC := make(chan interface{})
 
 	go func() {
 		time.Sleep(time.Second)
@@ -177,7 +194,7 @@ func TestExecuteCmdContextCancel(t *testing.T) {
 	h := getHttpExpect(
 		ctx,
 		t,
-		Route("sleep", []string{}),
+		Route("sleep", []string{}, slots, serverDoneC),
 	)
 	body := h.POST("/execute").
 		WithJSON(ExecuteCmdRequest{
@@ -197,11 +214,14 @@ func TestExecuteCmdContextCancel(t *testing.T) {
 
 func TestExecuteCmdCancel(t *testing.T) {
 	require := require.New(t)
+	slots := make(chan interface{}, 1)
+	slots <- true
+	serverDoneC := make(chan interface{})
 
 	h := getHttpExpect(
 		context.Background(),
 		t,
-		Route("sleep", []string{}),
+		Route("sleep", []string{}, slots, serverDoneC),
 	)
 
 	var wg sync.WaitGroup
@@ -272,6 +292,9 @@ func TestExecuteCmdCancel(t *testing.T) {
 func TestExecuteCmdContextCancelThenCmdCancel(t *testing.T) {
 	require := require.New(t)
 	ctx, cancel := context.WithCancel(context.Background())
+	slots := make(chan interface{}, 1)
+	slots <- true
+	serverDoneC := make(chan interface{})
 
 	go func() {
 		time.Sleep(time.Second)
@@ -281,7 +304,7 @@ func TestExecuteCmdContextCancelThenCmdCancel(t *testing.T) {
 	h := getHttpExpect(
 		ctx,
 		t,
-		Route("sleep", []string{}),
+		Route("sleep", []string{}, slots, serverDoneC),
 	)
 	body := h.POST("/execute").
 		WithJSON(ExecuteCmdRequest{
@@ -301,7 +324,7 @@ func TestExecuteCmdContextCancelThenCmdCancel(t *testing.T) {
 	h = getHttpExpect(
 		context.Background(),
 		t,
-		Route("sleep", []string{}),
+		Route("sleep", []string{}, slots, serverDoneC),
 	)
 	var wg sync.WaitGroup
 	wg.Add(1)

--- a/pkg/httpd/server_test.go
+++ b/pkg/httpd/server_test.go
@@ -50,13 +50,12 @@ func TestExecuteCmdSimpleEcho(t *testing.T) {
 	h := getHttpExpect(
 		context.Background(),
 		t,
-		Route("echo", []string{"hello"}, serverDoneC, slots),
+		Route("echo", []string{"hello"}, slots, serverDoneC),
 	)
 	body := h.POST("/execute").
 		WithJSON(map[string]interface{}{}).
 		Expect().
 		Status(http.StatusOK).Body()
-
 	outputs := parseOutputs(body.Raw(), require)
 	execID := outputs[0].ExecutionID
 	require.Equal(

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -124,6 +124,10 @@ func (l *StdErrLogger) SuggestSteps(title string, steps ...string) {
 	SuggestSteps(title, steps...)
 }
 
+func prependTimeToMsg(msg string) string {
+	return time.Now().Format(time.RFC3339Nano) + ": " + msg
+}
+
 // Log writes a log message to stderr, followed by a newline. Printf-style
 // formatting is applied to msg using args.
 func Log(msg string, args ...interface{}) {
@@ -133,6 +137,10 @@ func Log(msg string, args ...interface{}) {
 	} else {
 		fmt.Fprintf(os.Stderr, msg+"\n", args...)
 	}
+}
+
+func LogWithTime(msg string, args ...interface{}) {
+	Log(prependTimeToMsg(msg), args...)
 }
 
 // Step prints a step that was performed.
@@ -156,9 +164,17 @@ func Error(msg string, args ...interface{}) {
 	fmt.Fprintf(os.Stderr, Red("Error: ")+msg+"\n", args...)
 }
 
+func ErrorWithTime(msg string, args ...interface{}) {
+	Error(prependTimeToMsg(msg), args...)
+}
+
 // Warning logs a warning message.
 func Warning(msg string, args ...interface{}) {
 	fmt.Fprint(os.Stderr, Yellow("[warning] "+msg+"\n", args...))
+}
+
+func WarningWithTime(msg string, args ...interface{}) {
+	Warning(prependTimeToMsg(msg), args...)
 }
 
 // Debug writes a log message to stderr, followed by a newline, if the CLI
@@ -178,6 +194,10 @@ func Debug(msg string, args ...interface{}) {
 	msgf = debugPrefix + strings.Join(strings.Split(msgf, "\n"), "\n"+debugPrefix)
 
 	fmt.Fprint(os.Stderr, msgf+"\n")
+}
+
+func DebugWithTime(msg string, args ...interface{}) {
+	Debug(prependTimeToMsg(msg), args...)
 }
 
 type Loader interface {


### PR DESCRIPTION
## Description
When looking at httpd logs, it's much more useful to have the time in the log.

## Test plan
Ran unit tests
