### PR TITLE
Pass env var from dev config file into local run config

### DIFF
--- a/pkg/server/apiext.go
+++ b/pkg/server/apiext.go
@@ -135,6 +135,7 @@ func ExecuteTaskHandler(ctx context.Context, state *State, r *http.Request, req 
 			EnvSlug:     state.envSlug,
 			IsBuiltin:   isBuiltin,
 			LogBroker:   run.LogBroker,
+			Env:         state.devConfig.EnvVars,
 		}
 		resourceAttachments := map[string]string{}
 		// Builtins have a specific alias in the form of "rest", "db", etc. that is required by the builtins binary,


### PR DESCRIPTION
## Description
We aren't passing env vars from the dev config file into the task - this PR fixes that issue.

## Test plan
Tested a task with an environment variable.