### PR TITLE
Auto create missing task / view if no prompt available

### DIFF
--- a/cmd/airplane/tasks/deploy/deploy.go
+++ b/cmd/airplane/tasks/deploy/deploy.go
@@ -180,7 +180,7 @@ func HandleMissingTask(cfg config, l logger.LoggerWithLoader, createdTasks *map[
 				// User answered "no", so bail here.
 				return nil, nil
 			}
-		} else if !cfg.assumeYes {
+		} else if cfg.assumeNo {
 			return nil, nil
 		}
 
@@ -244,7 +244,7 @@ func HandleMissingView(cfg config, l logger.LoggerWithLoader, createdViews *map[
 				// User answered "no", so bail here.
 				return nil, nil
 			}
-		} else if !cfg.assumeYes {
+		} else if cfg.assumeNo {
 			return nil, nil
 		}
 


### PR DESCRIPTION
## Description

Context: A user requested that when they use the github action (which uses the CLI under the hood) they want tasks to be auto created. We do this for github deploys, but not for github action deploys since they use the CLI.

We could enable this with a flag, but we decided when doing github actions to automate task creation. If we're going to do it on that path, I don't see a reason why we wouldn't also do it on the CLI path. 

This change auto creates tasks if prompting is not supported. Thoughts?
