### PR TITLE
List remote resources alongside local resources

### DIFF
--- a/pkg/server/apiint/apiint.go
+++ b/pkg/server/apiint/apiint.go
@@ -182,7 +182,7 @@ func ListResourcesHandler(ctx context.Context, state *state.State, r *http.Reque
 		})
 	}
 
-	if state.EnvID == env.LocalEnvID {
+	if state.EnvID != env.LocalEnvID {
 		remoteResources, err := res.ListRemoteResources(ctx, state)
 		if err != nil {
 			return ListResourcesResponse{}, errors.Wrap(err, "fetching remote resources")

--- a/pkg/server/apiint/apiint.go
+++ b/pkg/server/apiint/apiint.go
@@ -157,7 +157,9 @@ func GetResourceHandler(ctx context.Context, state *state.State, r *http.Request
 
 type APIResourceWithEnv struct {
 	libapi.Resource
-	Remote bool `json:"remote"`
+	Remote  bool   `json:"remote"`
+	EnvID   string `json:"envID"`
+	EnvSlug string `json:"envSlug"`
 }
 
 type ListResourcesResponse struct {
@@ -178,7 +180,9 @@ func ListResourcesHandler(ctx context.Context, state *state.State, r *http.Reque
 				CanUseResource:    true,
 				CanUpdateResource: true,
 			},
-			Remote: false,
+			Remote:  false,
+			EnvID:   env.LocalEnvID,
+			EnvSlug: env.LocalEnvID,
 		})
 	}
 
@@ -196,6 +200,8 @@ func ListResourcesHandler(ctx context.Context, state *state.State, r *http.Reque
 			resources = append(resources, APIResourceWithEnv{
 				Resource: r,
 				Remote:   true,
+				EnvID:    state.EnvID,
+				EnvSlug:  state.EnvSlug,
 			})
 		}
 	}

--- a/pkg/server/apiint/apiint.go
+++ b/pkg/server/apiint/apiint.go
@@ -188,21 +188,21 @@ func ListResourcesHandler(ctx context.Context, state *state.State, r *http.Reque
 
 	if state.EnvID != env.LocalEnvID {
 		remoteResources, err := res.ListRemoteResources(ctx, state)
-		if err != nil {
-			return ListResourcesResponse{}, errors.Wrap(err, "fetching remote resources")
-		}
-
-		for _, r := range remoteResources {
-			// This is purely so we can display remote resource information in the local dev editor. The remote list
-			// resources endpoint doesn't return CanUseResource or CanUpdateResource, and so we set them to true here.
-			r.CanUseResource = true
-			r.CanUpdateResource = true
-			resources = append(resources, APIResourceWithEnv{
-				Resource: r,
-				Remote:   true,
-				EnvID:    state.EnvID,
-				EnvSlug:  state.EnvSlug,
-			})
+		if err == nil {
+			for _, r := range remoteResources {
+				// This is purely so we can display remote resource information in the local dev editor. The remote list
+				// resources endpoint doesn't return CanUseResource or CanUpdateResource, and so we set them to true here.
+				r.CanUseResource = true
+				r.CanUpdateResource = true
+				resources = append(resources, APIResourceWithEnv{
+					Resource: r,
+					Remote:   true,
+					EnvID:    state.EnvID,
+					EnvSlug:  state.EnvSlug,
+				})
+			}
+		} else {
+			logger.Error("error fetching remote resources: %v", err)
 		}
 	}
 

--- a/pkg/server/apiint/apiint.go
+++ b/pkg/server/apiint/apiint.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/airplanedev/cli/pkg/dev"
+	"github.com/airplanedev/cli/pkg/dev/env"
 	"github.com/airplanedev/cli/pkg/logger"
 	res "github.com/airplanedev/cli/pkg/resource"
 	"github.com/airplanedev/cli/pkg/server/handlers"
@@ -154,22 +155,52 @@ func GetResourceHandler(ctx context.Context, state *state.State, r *http.Request
 	return GetResourceResponse{}, errors.Errorf("Resource with slug %s is not in dev config file", slug)
 }
 
+type APIResourceWithEnv struct {
+	libapi.Resource
+	Remote bool `json:"remote"`
+}
+
+type ListResourcesResponse struct {
+	Resources []APIResourceWithEnv `json:"resources"`
+}
+
 // ListResourcesHandler handles requests to the /i/resources/list endpoint
-func ListResourcesHandler(ctx context.Context, state *state.State, r *http.Request) (libapi.ListResourcesResponse, error) {
-	resources := make([]libapi.Resource, 0, len(state.DevConfig.RawResources))
+func ListResourcesHandler(ctx context.Context, state *state.State, r *http.Request) (ListResourcesResponse, error) {
+	resources := make([]APIResourceWithEnv, 0)
 	for slug, r := range state.DevConfig.Resources {
-		resources = append(resources, libapi.Resource{
-			ID:                r.Resource.ID(),
-			Name:              slug, // TODO: Change to actual name of resource once that's exposed from export resource.
-			Slug:              slug,
-			Kind:              libapi.ResourceKind(r.Resource.Kind()),
-			ExportResource:    r.Resource,
-			CanUseResource:    true,
-			CanUpdateResource: true,
+		resources = append(resources, APIResourceWithEnv{
+			Resource: libapi.Resource{
+				ID:                r.Resource.ID(),
+				Name:              slug, // TODO: Change to actual name of resource once that's exposed from export resource.
+				Slug:              slug,
+				Kind:              libapi.ResourceKind(r.Resource.Kind()),
+				ExportResource:    r.Resource,
+				CanUseResource:    true,
+				CanUpdateResource: true,
+			},
+			Remote: false,
 		})
 	}
 
-	return libapi.ListResourcesResponse{
+	if state.EnvID == env.LocalEnvID {
+		remoteResources, err := res.ListRemoteResources(ctx, state)
+		if err != nil {
+			return ListResourcesResponse{}, errors.Wrap(err, "fetching remote resources")
+		}
+
+		for _, r := range remoteResources {
+			// This is purely so we can display remote resource information in the local dev editor. The remote list
+			// resources endpoint doesn't return CanUseResource or CanUpdateResource, and so we set them to true here.
+			r.CanUseResource = true
+			r.CanUpdateResource = true
+			resources = append(resources, APIResourceWithEnv{
+				Resource: r,
+				Remote:   true,
+			})
+		}
+	}
+
+	return ListResourcesResponse{
 		Resources: resources,
 	}, nil
 }

--- a/pkg/server/apiint/apiint_test/apiint_test.go
+++ b/pkg/server/apiint/apiint_test/apiint_test.go
@@ -58,6 +58,7 @@ func TestListResources(t *testing.T) {
 					},
 				},
 			},
+			EnvID: env.LocalEnvID,
 		}),
 	)
 


### PR DESCRIPTION
## Description

Return remote resources in the `/i/resources/list` endpoint of the local dev server if a fallback environment is specified. This will be used for listing remote resources in the editor sidebar, and is also required by the run details page for builtins executed against a remote resource.

## Test plan
Tested executing a task with a builtin and verified that run details page was populated with remote resource configuration.