### PR TITLE
Update lib version to v0.5.107

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.19
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.6
 	github.com/MakeNowJust/heredoc v1.0.0
-	github.com/airplanedev/lib v0.5.106
+	github.com/airplanedev/lib v0.5.107
 	github.com/airplanedev/ojson v0.1.0
 	github.com/airplanedev/trap v0.1.0
 	github.com/bep/debounce v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -129,8 +129,8 @@ github.com/acomagu/bufpipe v1.0.3/go.mod h1:mxdxdup/WdsKVreO5GpW4+M/1CE2sMG4jeGJ
 github.com/airplanedev/archiver v1.1.3-0.20210823174045-ee4b23880021 h1:epOU0k9ymss5SvqH10GOBzH57m5AJbiWLx62TZwk748=
 github.com/airplanedev/archiver v1.1.3-0.20210823174045-ee4b23880021/go.mod h1:Dsagf3j6EvFajY16ZIuDnVL64yFCWtvfXE0tfG33w/U=
 github.com/airplanedev/dlog v0.0.0-20210615011719-ca8d3becde5e h1:MeoR75I33g2XHKnTfRE67THlKm6fCoKQ3KcxsElHL4w=
-github.com/airplanedev/lib v0.5.106 h1:1tafzC9y1erkldKJEk0kCe9Bc6n6DNBnwidGWHJ07MA=
-github.com/airplanedev/lib v0.5.106/go.mod h1:ljqolI3LPfqjBoOxhOcwCAbN+1PhMzrbuRL8rBoeuos=
+github.com/airplanedev/lib v0.5.107 h1:1irlcTmcKWstNz5r9r8l+n4q7NmBUrBiZ5n6RsLQOvw=
+github.com/airplanedev/lib v0.5.107/go.mod h1:ljqolI3LPfqjBoOxhOcwCAbN+1PhMzrbuRL8rBoeuos=
 github.com/airplanedev/ojson v0.1.0 h1:KpEO5zr/9S2xj38Vijky5MWZQ5l2mtDLUoxkxBPVCoI=
 github.com/airplanedev/ojson v0.1.0/go.mod h1:OinOlkiLgGwp+/RkH/9vVAIs78tP+oku4bt5v+jshoA=
 github.com/airplanedev/path v0.0.1 h1:3xW/3y6gaKmIeBcHqzieMl5RcUubcazzoHblMqvk6W4=


### PR DESCRIPTION
## Description
This change updates lib to [`v0.5.107`](https://github.com/airplanedev/lib/tree/v0.5.107) in `cli`.

It was created by `update_lib.py`.