### PR TITLE
Use http for docker host

### DIFF
--- a/pkg/api/client.go
+++ b/pkg/api/client.go
@@ -776,7 +776,9 @@ func (c Client) host() string {
 }
 
 func (c Client) scheme() string {
-	if strings.HasPrefix(c.Host, "localhost") || strings.HasPrefix(c.Host, "127.0.0.1") {
+	if strings.HasPrefix(c.Host, "localhost") ||
+		strings.HasPrefix(c.Host, "127.0.0.1") ||
+		strings.HasPrefix(c.Host, "host.docker.internal") {
 		return "http://"
 	}
 	return "https://"


### PR DESCRIPTION
## Description
For local testing inside the sandbox image, our host is `host.docker.internal:8080`, which uses http only. If we don't do this, we get a `server gave HTTP response to HTTPS client` error upon starting the local dev server.

## Test plan
Built the CLI and tested with the sandbox image.