### PR TITLE
Simplify default View

### DIFF
--- a/cmd/airplane/root/initcmd/fixtures/view/my_view.airplane.tsx
+++ b/cmd/airplane/root/initcmd/fixtures/view/my_view.airplane.tsx
@@ -1,120 +1,44 @@
-import {
-  Column,
-  Stack,
-  Table,
-  Text,
-  Heading,
-  useComponentState,
-} from "@airplane/views";
+import { Callout, Heading, Link, Stack, Text } from "@airplane/views";
 import airplane from "airplane";
 
-// Put the main logic of the view here.
-// Views documentation: https://docs.airplane.dev/views/getting-started
-const ExampleView = () => {
-  const customersState = useComponentState();
-  const selectedCustomer = customersState.selectedRow;
-
+const MyView = () => {
   return (
-    <Stack>
-      <Heading>Customer overview</Heading>
-      <Text>An example view that showcases customers and users.</Text>
-      <Table
-        id={customersState.id}
-        title="Customers"
-        columns={customersCols}
-        data={customersData}
-        rowSelection="single"
-      />
-      {selectedCustomer && (
-        <Table
-          title={`Users for ${selectedCustomer.name}`}
-          data={usersData.filter((u) => u.customer_id == selectedCustomer.id)}
-          columns={usersCols}
-          hiddenColumns={["customer_id"]}
-        />
-      )}
+    <Stack spacing="lg">
+      <Stack spacing={0}>
+        <Heading>👋 Hello, world!</Heading>
+        <Text>Views make it easy to build UIs in Airplane.</Text>
+      </Stack>
+      <Stack spacing={0}>
+        <Heading level={3}>Learn more</Heading>
+        <Stack direction="row">
+          <Callout variant="neutral" title="Overview" width="1/3">
+            {"Check out what you can build with views. "}
+            <Link href="https://docs.airplane.dev/views/overview" size="sm">
+              Read the docs.
+            </Link>
+          </Callout>
+          <Callout variant="neutral" title="Build your first view" width="1/3">
+            {"Walk through building a simple view in 15 minutes. "}
+            <Link href="https://docs.airplane.dev/getting-started/views" size="sm">
+              Read the docs.
+            </Link>
+          </Callout>
+          <Callout variant="neutral" title="Component library" width="1/3">
+            {"Browse the Views component library. "}
+            <Link href="https://docs.airplane.dev/views/components" size="sm">
+              Read the docs.
+            </Link>
+          </Callout>
+        </Stack>
+      </Stack>
     </Stack>
   );
 };
-
-// Example data: replace with your own data or use an Airplane task
-// Data fetching documentation: https://docs.airplane.dev/views/data-fetching
-const customersData = [
-  {
-    id: "0",
-    name: "Future Golf Partners",
-    country: "Brazil",
-  },
-  {
-    id: "1",
-    name: "Blue Sky Corp",
-    country: "France",
-  },
-];
-
-const usersData = [
-  {
-    id: "1",
-    customer_id: "0",
-    name: "Frances Hernandez",
-    role: "Engineer",
-    email: "frances.hernandez@futuregolfpartners.com",
-  },
-  {
-    id: "2",
-    customer_id: "0",
-    name: "Melissa Rodriguez",
-    role: "Engineer",
-    email: "melissa.rodriguez@futuregolfpartners.com",
-  },
-  {
-    id: "3",
-    customer_id: "1",
-    name: "Roy Hernandez",
-    role: "Sales",
-    email: "roy.hernandez.1@blueskycorp.us",
-  },
-];
-// End of example data
-
-const customersCols: Column[] = [
-  {
-    label: "Customer ID",
-    accessor: "id",
-  },
-  {
-    label: "Name",
-    accessor: "name",
-  },
-  {
-    label: "Country",
-    accessor: "country",
-  },
-];
-
-const usersCols: Column[] = [
-  {
-    label: "User ID",
-    accessor: "id",
-  },
-  {
-    label: "Name",
-    accessor: "name",
-  },
-  {
-    label: "Role",
-    accessor: "role",
-  },
-  {
-    label: "Email",
-    accessor: "email",
-  },
-];
 
 export default airplane.view(
   {
     slug: "my_view",
     name: "My view",
   },
-  ExampleView
+  MyView
 );

--- a/cmd/airplane/root/initcmd/fixtures/view/my_view.airplane.tsx
+++ b/cmd/airplane/root/initcmd/fixtures/view/my_view.airplane.tsx
@@ -11,21 +11,21 @@ const MyView = () => {
       <Stack spacing={0}>
         <Heading level={3}>Learn more</Heading>
         <Stack direction="row">
-          <Callout variant="neutral" title="Overview" width="1/3">
-            {"Check out what you can build with views. "}
-            <Link href="https://docs.airplane.dev/views/overview" size="sm">
-              Read the docs.
-            </Link>
-          </Callout>
           <Callout variant="neutral" title="Build your first view" width="1/3">
             {"Walk through building a simple view in 15 minutes. "}
             <Link href="https://docs.airplane.dev/getting-started/views" size="sm">
               Read the docs.
             </Link>
           </Callout>
-          <Callout variant="neutral" title="Component library" width="1/3">
-            {"Browse the Views component library. "}
-            <Link href="https://docs.airplane.dev/views/components" size="sm">
+          <Callout variant="neutral" title="Templates" width="1/3">
+            {"Work off of one of our many ready-made templates. "}
+            <Link href="https://docs.airplane.dev/templates" size="sm">
+              See our templates.
+            </Link>
+          </Callout>
+          <Callout variant="neutral" title="Reference" width="1/3">
+            {"Learn more about how to supercharge your views. "}
+            <Link href="https://docs.airplane.dev" size="sm">
               Read the docs.
             </Link>
           </Callout>

--- a/cmd/airplane/views/initcmd/fixtures/noninline/noninline_view/noninline_view.view.tsx
+++ b/cmd/airplane/views/initcmd/fixtures/noninline/noninline_view/noninline_view.view.tsx
@@ -1,113 +1,37 @@
-import {
-  Column,
-  Stack,
-  Table,
-  Text,
-  Heading,
-  useComponentState,
-} from "@airplane/views";
+import { Callout, Heading, Link, Stack, Text } from "@airplane/views";
 
-// Put the main logic of the view here.
-// Views documentation: https://docs.airplane.dev/views/getting-started
-const ExampleView = () => {
-  const customersState = useComponentState();
-  const selectedCustomer = customersState.selectedRow;
-
+const NoninlineView = () => {
   return (
-    <Stack>
-      <Heading>Customer overview</Heading>
-      <Text>An example view that showcases customers and users.</Text>
-      <Table
-        id={customersState.id}
-        title="Customers"
-        columns={customersCols}
-        data={customersData}
-        rowSelection="single"
-      />
-      {selectedCustomer && (
-        <Table
-          title={`Users for ${selectedCustomer.name}`}
-          data={usersData.filter((u) => u.customer_id == selectedCustomer.id)}
-          columns={usersCols}
-          hiddenColumns={["customer_id"]}
-        />
-      )}
+    <Stack spacing="lg">
+      <Stack spacing={0}>
+        <Heading>👋 Hello, world!</Heading>
+        <Text>Views make it easy to build UIs in Airplane.</Text>
+      </Stack>
+      <Stack spacing={0}>
+        <Heading level={3}>Learn more</Heading>
+        <Stack direction="row">
+          <Callout variant="neutral" title="Overview" width="1/3">
+            {"Check out what you can build with views. "}
+            <Link href="https://docs.airplane.dev/views/overview" size="sm">
+              Read the docs.
+            </Link>
+          </Callout>
+          <Callout variant="neutral" title="Build your first view" width="1/3">
+            {"Walk through building a simple view in 15 minutes. "}
+            <Link href="https://docs.airplane.dev/getting-started/views" size="sm">
+              Read the docs.
+            </Link>
+          </Callout>
+          <Callout variant="neutral" title="Component library" width="1/3">
+            {"Browse the Views component library. "}
+            <Link href="https://docs.airplane.dev/views/components" size="sm">
+              Read the docs.
+            </Link>
+          </Callout>
+        </Stack>
+      </Stack>
     </Stack>
   );
 };
 
-// Example data: replace with your own data or use an Airplane task
-// Data fetching documentation: https://docs.airplane.dev/views/data-fetching
-const customersData = [
-  {
-    id: "0",
-    name: "Future Golf Partners",
-    country: "Brazil",
-  },
-  {
-    id: "1",
-    name: "Blue Sky Corp",
-    country: "France",
-  },
-];
-
-const usersData = [
-  {
-    id: "1",
-    customer_id: "0",
-    name: "Frances Hernandez",
-    role: "Engineer",
-    email: "frances.hernandez@futuregolfpartners.com",
-  },
-  {
-    id: "2",
-    customer_id: "0",
-    name: "Melissa Rodriguez",
-    role: "Engineer",
-    email: "melissa.rodriguez@futuregolfpartners.com",
-  },
-  {
-    id: "3",
-    customer_id: "1",
-    name: "Roy Hernandez",
-    role: "Sales",
-    email: "roy.hernandez.1@blueskycorp.us",
-  },
-];
-// End of example data
-
-const customersCols: Column[] = [
-  {
-    label: "Customer ID",
-    accessor: "id",
-  },
-  {
-    label: "Name",
-    accessor: "name",
-  },
-  {
-    label: "Country",
-    accessor: "country",
-  },
-];
-
-const usersCols: Column[] = [
-  {
-    label: "User ID",
-    accessor: "id",
-  },
-  {
-    label: "Name",
-    accessor: "name",
-  },
-  {
-    label: "Role",
-    accessor: "role",
-  },
-  {
-    label: "Email",
-    accessor: "email",
-  },
-];
-
-export default ExampleView;
+export default NoninlineView;

--- a/cmd/airplane/views/initcmd/fixtures/noninline/noninline_view/noninline_view.view.tsx
+++ b/cmd/airplane/views/initcmd/fixtures/noninline/noninline_view/noninline_view.view.tsx
@@ -10,21 +10,21 @@ const NoninlineView = () => {
       <Stack spacing={0}>
         <Heading level={3}>Learn more</Heading>
         <Stack direction="row">
-          <Callout variant="neutral" title="Overview" width="1/3">
-            {"Check out what you can build with views. "}
-            <Link href="https://docs.airplane.dev/views/overview" size="sm">
-              Read the docs.
-            </Link>
-          </Callout>
           <Callout variant="neutral" title="Build your first view" width="1/3">
             {"Walk through building a simple view in 15 minutes. "}
             <Link href="https://docs.airplane.dev/getting-started/views" size="sm">
               Read the docs.
             </Link>
           </Callout>
-          <Callout variant="neutral" title="Component library" width="1/3">
-            {"Browse the Views component library. "}
-            <Link href="https://docs.airplane.dev/views/components" size="sm">
+          <Callout variant="neutral" title="Templates" width="1/3">
+            {"Work off of one of our many ready-made templates. "}
+            <Link href="https://docs.airplane.dev/templates" size="sm">
+              See our templates.
+            </Link>
+          </Callout>
+          <Callout variant="neutral" title="Reference" width="1/3">
+            {"Learn more about how to supercharge your views. "}
+            <Link href="https://docs.airplane.dev" size="sm">
               Read the docs.
             </Link>
           </Callout>

--- a/cmd/airplane/views/initcmd/fixtures/view/my_view.airplane.tsx
+++ b/cmd/airplane/views/initcmd/fixtures/view/my_view.airplane.tsx
@@ -1,120 +1,44 @@
-import {
-  Column,
-  Stack,
-  Table,
-  Text,
-  Heading,
-  useComponentState,
-} from "@airplane/views";
+import { Callout, Heading, Link, Stack, Text } from "@airplane/views";
 import airplane from "airplane";
 
-// Put the main logic of the view here.
-// Views documentation: https://docs.airplane.dev/views/getting-started
-const ExampleView = () => {
-  const customersState = useComponentState();
-  const selectedCustomer = customersState.selectedRow;
-
+const MyView = () => {
   return (
-    <Stack>
-      <Heading>Customer overview</Heading>
-      <Text>An example view that showcases customers and users.</Text>
-      <Table
-        id={customersState.id}
-        title="Customers"
-        columns={customersCols}
-        data={customersData}
-        rowSelection="single"
-      />
-      {selectedCustomer && (
-        <Table
-          title={`Users for ${selectedCustomer.name}`}
-          data={usersData.filter((u) => u.customer_id == selectedCustomer.id)}
-          columns={usersCols}
-          hiddenColumns={["customer_id"]}
-        />
-      )}
+    <Stack spacing="lg">
+      <Stack spacing={0}>
+        <Heading>👋 Hello, world!</Heading>
+        <Text>Views make it easy to build UIs in Airplane.</Text>
+      </Stack>
+      <Stack spacing={0}>
+        <Heading level={3}>Learn more</Heading>
+        <Stack direction="row">
+          <Callout variant="neutral" title="Overview" width="1/3">
+            {"Check out what you can build with views. "}
+            <Link href="https://docs.airplane.dev/views/overview" size="sm">
+              Read the docs.
+            </Link>
+          </Callout>
+          <Callout variant="neutral" title="Build your first view" width="1/3">
+            {"Walk through building a simple view in 15 minutes. "}
+            <Link href="https://docs.airplane.dev/getting-started/views" size="sm">
+              Read the docs.
+            </Link>
+          </Callout>
+          <Callout variant="neutral" title="Component library" width="1/3">
+            {"Browse the Views component library. "}
+            <Link href="https://docs.airplane.dev/views/components" size="sm">
+              Read the docs.
+            </Link>
+          </Callout>
+        </Stack>
+      </Stack>
     </Stack>
   );
 };
-
-// Example data: replace with your own data or use an Airplane task
-// Data fetching documentation: https://docs.airplane.dev/views/data-fetching
-const customersData = [
-  {
-    id: "0",
-    name: "Future Golf Partners",
-    country: "Brazil",
-  },
-  {
-    id: "1",
-    name: "Blue Sky Corp",
-    country: "France",
-  },
-];
-
-const usersData = [
-  {
-    id: "1",
-    customer_id: "0",
-    name: "Frances Hernandez",
-    role: "Engineer",
-    email: "frances.hernandez@futuregolfpartners.com",
-  },
-  {
-    id: "2",
-    customer_id: "0",
-    name: "Melissa Rodriguez",
-    role: "Engineer",
-    email: "melissa.rodriguez@futuregolfpartners.com",
-  },
-  {
-    id: "3",
-    customer_id: "1",
-    name: "Roy Hernandez",
-    role: "Sales",
-    email: "roy.hernandez.1@blueskycorp.us",
-  },
-];
-// End of example data
-
-const customersCols: Column[] = [
-  {
-    label: "Customer ID",
-    accessor: "id",
-  },
-  {
-    label: "Name",
-    accessor: "name",
-  },
-  {
-    label: "Country",
-    accessor: "country",
-  },
-];
-
-const usersCols: Column[] = [
-  {
-    label: "User ID",
-    accessor: "id",
-  },
-  {
-    label: "Name",
-    accessor: "name",
-  },
-  {
-    label: "Role",
-    accessor: "role",
-  },
-  {
-    label: "Email",
-    accessor: "email",
-  },
-];
 
 export default airplane.view(
   {
     slug: "my_view",
     name: "My view",
   },
-  ExampleView
+  MyView
 );

--- a/cmd/airplane/views/initcmd/fixtures/view/my_view.airplane.tsx
+++ b/cmd/airplane/views/initcmd/fixtures/view/my_view.airplane.tsx
@@ -11,21 +11,21 @@ const MyView = () => {
       <Stack spacing={0}>
         <Heading level={3}>Learn more</Heading>
         <Stack direction="row">
-          <Callout variant="neutral" title="Overview" width="1/3">
-            {"Check out what you can build with views. "}
-            <Link href="https://docs.airplane.dev/views/overview" size="sm">
-              Read the docs.
-            </Link>
-          </Callout>
           <Callout variant="neutral" title="Build your first view" width="1/3">
             {"Walk through building a simple view in 15 minutes. "}
             <Link href="https://docs.airplane.dev/getting-started/views" size="sm">
               Read the docs.
             </Link>
           </Callout>
-          <Callout variant="neutral" title="Component library" width="1/3">
-            {"Browse the Views component library. "}
-            <Link href="https://docs.airplane.dev/views/components" size="sm">
+          <Callout variant="neutral" title="Templates" width="1/3">
+            {"Work off of one of our many ready-made templates. "}
+            <Link href="https://docs.airplane.dev/templates" size="sm">
+              See our templates.
+            </Link>
+          </Callout>
+          <Callout variant="neutral" title="Reference" width="1/3">
+            {"Learn more about how to supercharge your views. "}
+            <Link href="https://docs.airplane.dev" size="sm">
               Read the docs.
             </Link>
           </Callout>

--- a/cmd/airplane/views/initcmd/scaffolding/default.view.tsx
+++ b/cmd/airplane/views/initcmd/scaffolding/default.view.tsx
@@ -1,17 +1,36 @@
-import { Heading, Stack, Table } from "@airplane/views";
+import { Callout, Heading, Link, Stack, Text } from "@airplane/views";
+
 
 const {{.ViewName}} = () => {
   return (
-    <Stack>
-      <Heading>Users</Heading>
-      <Table
-        title="Users"
-        data={[
-          { name: "Frances Hernandez", role: "Engineer" },
-          { name: "Charlotte Morris", role: "Sales" },
-          { name: "Ju Hsiao", role: "Support" },
-        ]}
-      />
+    <Stack spacing="lg">
+      <Stack spacing={0}>
+        <Heading>👋 Hello, world!</Heading>
+        <Text>Views make it easy to build UIs in Airplane.</Text>
+      </Stack>
+      <Stack spacing={0}>
+        <Heading level={3}>Learn more</Heading>
+        <Stack direction="row">
+          <Callout variant="neutral" title="Overview" width="1/3">
+            {"Check out what you can build with views. "}
+            <Link href="https://docs.airplane.dev/views/overview" size="sm">
+              Read the docs.
+            </Link>
+          </Callout>
+          <Callout variant="neutral" title="Build your first view" width="1/3">
+            {"Walk through building a simple view in 15 minutes. "}
+            <Link href="https://docs.airplane.dev/getting-started/views" size="sm">
+              Read the docs.
+            </Link>
+          </Callout>
+          <Callout variant="neutral" title="Component library" width="1/3">
+            {"Browse the Views component library. "}
+            <Link href="https://docs.airplane.dev/views/components" size="sm">
+              Read the docs.
+            </Link>
+          </Callout>
+        </Stack>
+      </Stack>
     </Stack>
   );
 };

--- a/cmd/airplane/views/initcmd/scaffolding/default.view.tsx
+++ b/cmd/airplane/views/initcmd/scaffolding/default.view.tsx
@@ -1,113 +1,19 @@
-import {
-  Column,
-  Stack,
-  Table,
-  Text,
-  Heading,
-  useComponentState,
-} from "@airplane/views";
+import { Heading, Stack, Table } from "@airplane/views";
 
-// Put the main logic of the view here.
-// Views documentation: https://docs.airplane.dev/views/getting-started
-const ExampleView = () => {
-  const customersState = useComponentState();
-  const selectedCustomer = customersState.selectedRow;
-
+const {{.ViewName}} = () => {
   return (
     <Stack>
-      <Heading>Customer overview</Heading>
-      <Text>An example view that showcases customers and users.</Text>
+      <Heading>Users</Heading>
       <Table
-        id={customersState.id}
-        title="Customers"
-        columns={customersCols}
-        data={customersData}
-        rowSelection="single"
+        title="Users"
+        data={[
+          { name: "Frances Hernandez", role: "Engineer" },
+          { name: "Charlotte Morris", role: "Sales" },
+          { name: "Ju Hsiao", role: "Support" },
+        ]}
       />
-      {selectedCustomer && (
-        <Table
-          title={`Users for ${selectedCustomer.name}`}
-          data={usersData.filter((u) => u.customer_id == selectedCustomer.id)}
-          columns={usersCols}
-          hiddenColumns={["customer_id"]}
-        />
-      )}
     </Stack>
   );
 };
 
-// Example data: replace with your own data or use an Airplane task
-// Data fetching documentation: https://docs.airplane.dev/views/data-fetching
-const customersData = [
-  {
-    id: "0",
-    name: "Future Golf Partners",
-    country: "Brazil",
-  },
-  {
-    id: "1",
-    name: "Blue Sky Corp",
-    country: "France",
-  },
-];
-
-const usersData = [
-  {
-    id: "1",
-    customer_id: "0",
-    name: "Frances Hernandez",
-    role: "Engineer",
-    email: "frances.hernandez@futuregolfpartners.com",
-  },
-  {
-    id: "2",
-    customer_id: "0",
-    name: "Melissa Rodriguez",
-    role: "Engineer",
-    email: "melissa.rodriguez@futuregolfpartners.com",
-  },
-  {
-    id: "3",
-    customer_id: "1",
-    name: "Roy Hernandez",
-    role: "Sales",
-    email: "roy.hernandez.1@blueskycorp.us",
-  },
-];
-// End of example data
-
-const customersCols: Column[] = [
-  {
-    label: "Customer ID",
-    accessor: "id",
-  },
-  {
-    label: "Name",
-    accessor: "name",
-  },
-  {
-    label: "Country",
-    accessor: "country",
-  },
-];
-
-const usersCols: Column[] = [
-  {
-    label: "User ID",
-    accessor: "id",
-  },
-  {
-    label: "Name",
-    accessor: "name",
-  },
-  {
-    label: "Role",
-    accessor: "role",
-  },
-  {
-    label: "Email",
-    accessor: "email",
-  },
-];
-
-export default ExampleView;
+export default {{.ViewName}};

--- a/cmd/airplane/views/initcmd/scaffolding/default.view.tsx
+++ b/cmd/airplane/views/initcmd/scaffolding/default.view.tsx
@@ -1,6 +1,5 @@
 import { Callout, Heading, Link, Stack, Text } from "@airplane/views";
 
-
 const {{.ViewName}} = () => {
   return (
     <Stack spacing="lg">

--- a/cmd/airplane/views/initcmd/scaffolding/default.view.tsx
+++ b/cmd/airplane/views/initcmd/scaffolding/default.view.tsx
@@ -10,21 +10,21 @@ const {{.ViewName}} = () => {
       <Stack spacing={0}>
         <Heading level={3}>Learn more</Heading>
         <Stack direction="row">
-          <Callout variant="neutral" title="Overview" width="1/3">
-            {"Check out what you can build with views. "}
-            <Link href="https://docs.airplane.dev/views/overview" size="sm">
-              Read the docs.
-            </Link>
-          </Callout>
           <Callout variant="neutral" title="Build your first view" width="1/3">
             {"Walk through building a simple view in 15 minutes. "}
             <Link href="https://docs.airplane.dev/getting-started/views" size="sm">
               Read the docs.
             </Link>
           </Callout>
-          <Callout variant="neutral" title="Component library" width="1/3">
-            {"Browse the Views component library. "}
-            <Link href="https://docs.airplane.dev/views/components" size="sm">
+          <Callout variant="neutral" title="Templates" width="1/3">
+            {"Work off of one of our many ready-made templates. "}
+            <Link href="https://docs.airplane.dev/templates" size="sm">
+              See our templates.
+            </Link>
+          </Callout>
+          <Callout variant="neutral" title="Reference" width="1/3">
+            {"Learn more about how to supercharge your views. "}
+            <Link href="https://docs.airplane.dev" size="sm">
               Read the docs.
             </Link>
           </Callout>

--- a/cmd/airplane/views/initcmd/scaffolding/default_inline.airplane.tsx
+++ b/cmd/airplane/views/initcmd/scaffolding/default_inline.airplane.tsx
@@ -1,120 +1,26 @@
-import {
-  Column,
-  Stack,
-  Table,
-  Text,
-  Heading,
-  useComponentState,
-} from "@airplane/views";
+import { Heading, Stack, Table } from "@airplane/views";
 import airplane from "airplane";
 
-// Put the main logic of the view here.
-// Views documentation: https://docs.airplane.dev/views/getting-started
-const ExampleView = () => {
-  const customersState = useComponentState();
-  const selectedCustomer = customersState.selectedRow;
-
+const {{.ViewName}} = () => {
   return (
     <Stack>
-      <Heading>Customer overview</Heading>
-      <Text>An example view that showcases customers and users.</Text>
+      <Heading>Users</Heading>
       <Table
-        id={customersState.id}
-        title="Customers"
-        columns={customersCols}
-        data={customersData}
-        rowSelection="single"
+        title="Users"
+        data={[
+          { name: "Frances Hernandez", role: "Engineer" },
+          { name: "Charlotte Morris", role: "Sales" },
+          { name: "Ju Hsiao", role: "Support" },
+        ]}
       />
-      {selectedCustomer && (
-        <Table
-          title={`Users for ${selectedCustomer.name}`}
-          data={usersData.filter((u) => u.customer_id == selectedCustomer.id)}
-          columns={usersCols}
-          hiddenColumns={["customer_id"]}
-        />
-      )}
     </Stack>
   );
 };
-
-// Example data: replace with your own data or use an Airplane task
-// Data fetching documentation: https://docs.airplane.dev/views/data-fetching
-const customersData = [
-  {
-    id: "0",
-    name: "Future Golf Partners",
-    country: "Brazil",
-  },
-  {
-    id: "1",
-    name: "Blue Sky Corp",
-    country: "France",
-  },
-];
-
-const usersData = [
-  {
-    id: "1",
-    customer_id: "0",
-    name: "Frances Hernandez",
-    role: "Engineer",
-    email: "frances.hernandez@futuregolfpartners.com",
-  },
-  {
-    id: "2",
-    customer_id: "0",
-    name: "Melissa Rodriguez",
-    role: "Engineer",
-    email: "melissa.rodriguez@futuregolfpartners.com",
-  },
-  {
-    id: "3",
-    customer_id: "1",
-    name: "Roy Hernandez",
-    role: "Sales",
-    email: "roy.hernandez.1@blueskycorp.us",
-  },
-];
-// End of example data
-
-const customersCols: Column[] = [
-  {
-    label: "Customer ID",
-    accessor: "id",
-  },
-  {
-    label: "Name",
-    accessor: "name",
-  },
-  {
-    label: "Country",
-    accessor: "country",
-  },
-];
-
-const usersCols: Column[] = [
-  {
-    label: "User ID",
-    accessor: "id",
-  },
-  {
-    label: "Name",
-    accessor: "name",
-  },
-  {
-    label: "Role",
-    accessor: "role",
-  },
-  {
-    label: "Email",
-    accessor: "email",
-  },
-];
 
 export default airplane.view(
   {
     slug: "{{.Slug}}",
     name: "{{.Name}}",
   },
-  ExampleView
+  {{.ViewName}}
 );

--- a/cmd/airplane/views/initcmd/scaffolding/default_inline.airplane.tsx
+++ b/cmd/airplane/views/initcmd/scaffolding/default_inline.airplane.tsx
@@ -1,18 +1,36 @@
-import { Heading, Stack, Table } from "@airplane/views";
+import { Callout, Heading, Link, Stack, Text } from "@airplane/views";
 import airplane from "airplane";
 
 const {{.ViewName}} = () => {
   return (
-    <Stack>
-      <Heading>Users</Heading>
-      <Table
-        title="Users"
-        data={[
-          { name: "Frances Hernandez", role: "Engineer" },
-          { name: "Charlotte Morris", role: "Sales" },
-          { name: "Ju Hsiao", role: "Support" },
-        ]}
-      />
+    <Stack spacing="lg">
+      <Stack spacing={0}>
+        <Heading>👋 Hello, world!</Heading>
+        <Text>Views make it easy to build UIs in Airplane.</Text>
+      </Stack>
+      <Stack spacing={0}>
+        <Heading level={3}>Learn more</Heading>
+        <Stack direction="row">
+          <Callout variant="neutral" title="Overview" width="1/3">
+            {"Check out what you can build with views. "}
+            <Link href="https://docs.airplane.dev/views/overview" size="sm">
+              Read the docs.
+            </Link>
+          </Callout>
+          <Callout variant="neutral" title="Build your first view" width="1/3">
+            {"Walk through building a simple view in 15 minutes. "}
+            <Link href="https://docs.airplane.dev/getting-started/views" size="sm">
+              Read the docs.
+            </Link>
+          </Callout>
+          <Callout variant="neutral" title="Component library" width="1/3">
+            {"Browse the Views component library. "}
+            <Link href="https://docs.airplane.dev/views/components" size="sm">
+              Read the docs.
+            </Link>
+          </Callout>
+        </Stack>
+      </Stack>
     </Stack>
   );
 };

--- a/cmd/airplane/views/initcmd/scaffolding/default_inline.airplane.tsx
+++ b/cmd/airplane/views/initcmd/scaffolding/default_inline.airplane.tsx
@@ -11,21 +11,21 @@ const {{.ViewName}} = () => {
       <Stack spacing={0}>
         <Heading level={3}>Learn more</Heading>
         <Stack direction="row">
-          <Callout variant="neutral" title="Overview" width="1/3">
-            {"Check out what you can build with views. "}
-            <Link href="https://docs.airplane.dev/views/overview" size="sm">
-              Read the docs.
-            </Link>
-          </Callout>
           <Callout variant="neutral" title="Build your first view" width="1/3">
             {"Walk through building a simple view in 15 minutes. "}
             <Link href="https://docs.airplane.dev/getting-started/views" size="sm">
               Read the docs.
             </Link>
           </Callout>
-          <Callout variant="neutral" title="Component library" width="1/3">
-            {"Browse the Views component library. "}
-            <Link href="https://docs.airplane.dev/views/components" size="sm">
+          <Callout variant="neutral" title="Templates" width="1/3">
+            {"Work off of one of our many ready-made templates. "}
+            <Link href="https://docs.airplane.dev/templates" size="sm">
+              See our templates.
+            </Link>
+          </Callout>
+          <Callout variant="neutral" title="Reference" width="1/3">
+            {"Learn more about how to supercharge your views. "}
+            <Link href="https://docs.airplane.dev" size="sm">
               Read the docs.
             </Link>
           </Callout>

--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 	github.com/hashicorp/go-retryablehttp v0.7.2
 	github.com/hashicorp/golang-lru/v2 v2.0.1
 	github.com/hexops/gotextdiff v1.0.3
+	github.com/iancoleman/strcase v0.2.0
 	github.com/joho/godotenv v1.5.1
 	github.com/kr/text v0.2.0
 	github.com/mattn/go-isatty v0.0.17

--- a/go.sum
+++ b/go.sum
@@ -328,6 +328,8 @@ github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSo
 github.com/hinshun/vt10x v0.0.0-20220119200601-820417d04eec h1:qv2VnGeEQHchGaZ/u7lxST/RaJw+cv273q79D81Xbog=
 github.com/hinshun/vt10x v0.0.0-20220119200601-820417d04eec/go.mod h1:Q48J4R4DvxnHolD5P8pOtXigYlRuPLGl6moFx3ulM68=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
+github.com/iancoleman/strcase v0.2.0 h1:05I4QRnGpI0m37iZQRuskXh+w77mr6Z41lwQzuHLwW0=
+github.com/iancoleman/strcase v0.2.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=
 github.com/imdario/mergo v0.3.13 h1:lFzP57bqS/wsqKssCGmtLAb8A0wKjLGrve2q3PPVcBk=
 github.com/imdario/mergo v0.3.13/go.mod h1:4lJ1jqUDcsbIECGy0RUJAXNIhg+6ocWgb1ALK2O4oXg=
 github.com/imkira/go-interpol v1.1.0 h1:KIiKr0VSG2CUW1hl1jpiyuzuJeKUUpC8iM1AIE7N1Vk=


### PR DESCRIPTION
## Description

* Simplify default view by removing a bunch of fluff
* Make the View component name based off of the view name rather than being `ExampleView`

<img width="1403" alt="image" src="https://user-images.githubusercontent.com/1384161/228705128-429acd47-f84a-410a-9356-4067cc767c81.png">

## Test plan

Build CLI locally and went through `airplane views init` flow

Fix tests